### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that provides AI-powered theatrical lighting design capabilities for the LacyLights system.
 
+<a href="https://glama.ai/mcp/servers/@bbernstein/lacylights-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bbernstein/lacylights-mcp/badge" alt="LacyLights Server MCP server" />
+</a>
+
 ## Features
 
 ### Fixture Management
@@ -136,7 +140,6 @@ which node
 ```
 
 **Note**: Use the absolute path to `run-mcp.js` in your configuration. This wrapper ensures proper CommonJS module loading.
-```
 
 ## Example Usage
 


### PR DESCRIPTION
This PR adds a badge for the [LacyLights MCP Server](https://glama.ai/mcp/servers/@bbernstein/lacylights-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@bbernstein/lacylights-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bbernstein/lacylights-mcp/badge" alt="LacyLights Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.