### PR TITLE
Fix README.md markdown formatting issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ which node
 ```
 
 **Note**: Use the absolute path to `run-mcp.js` in your configuration. This wrapper ensures proper CommonJS module loading.
-```
 
 ## Example Usage
 


### PR DESCRIPTION
## Summary
Fixes markdown rendering issue in README.md where headers were appearing as code instead of properly formatted headers.

## Problem
The README.md file had an unclosed code block (extra closing backticks ``` at line 139) that was causing everything after that point to be rendered as code instead of markdown. This made sections like:

- `## Example Usage`
- `### Generate a Scene`  
- `### Analyze a Script`
- `### Create Cue Sequence`

Appear as code text instead of proper headers when viewed in markdown readers.

## Solution
- Removed the extraneous closing backticks (```) that weren't paired with an opening code block
- This allows the markdown to render properly with correct header formatting
- All sections now display as intended H2/H3 headers

## Testing
- Verified the markdown structure is now correct
- Headers should now render properly in GitHub, VS Code, and other markdown readers
- No other content was affected - only the formatting issue was resolved

## Files Changed
- `README.md` - Removed 1 line with improper closing code block

This is a minor but important fix for documentation readability.

🤖 Generated with [Claude Code](https://claude.ai/code)