### PR TITLE
Add comprehensive scene activation and cue list playback functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -467,6 +467,10 @@ class LacyLightsMCPServer {
                     },
                   },
                 },
+                activate: {
+                  type: "boolean",
+                  description: "Automatically activate the scene after creation",
+                },
               },
               required: ["projectId", "sceneDescription"],
             },
@@ -571,6 +575,49 @@ class LacyLightsMCPServer {
                 },
               },
               required: ["sceneId"],
+            },
+          },
+          {
+            name: "activate_scene",
+            description: "Activate a lighting scene by name or ID",
+            inputSchema: {
+              type: "object",
+              properties: {
+                projectId: {
+                  type: "string",
+                  description: "Optional project ID to search within",
+                },
+                sceneId: {
+                  type: "string",
+                  description: "Scene ID to activate",
+                },
+                sceneName: {
+                  type: "string",
+                  description: "Scene name to activate (searches across projects if projectId not provided)",
+                },
+              },
+            },
+          },
+          {
+            name: "fade_to_black",
+            description: "Fade all lights to black (turn off)",
+            inputSchema: {
+              type: "object",
+              properties: {
+                fadeOutTime: {
+                  type: "number",
+                  default: 3.0,
+                  description: "Time in seconds to fade out (default: 3.0)",
+                },
+              },
+            },
+          },
+          {
+            name: "get_current_active_scene",
+            description: "Get the currently active scene if any",
+            inputSchema: {
+              type: "object",
+              properties: {},
             },
           },
           // Cue Tools
@@ -947,6 +994,95 @@ class LacyLightsMCPServer {
               required: ["cueListId", "confirmDelete"],
             },
           },
+          // Cue List Playback Tools
+          {
+            name: "start_cue_list",
+            description: "Start playing a cue list from the beginning or a specific cue",
+            inputSchema: {
+              type: "object",
+              properties: {
+                cueListId: {
+                  type: "string",
+                  description: "Cue list ID to play",
+                },
+                cueListName: {
+                  type: "string",
+                  description: "Cue list name to search for (alternative to ID)",
+                },
+                projectId: {
+                  type: "string",
+                  description: "Project ID to search within (optional when using cueListName)",
+                },
+                startFromCue: {
+                  type: "number",
+                  description: "Cue number to start from (optional, defaults to first cue)",
+                },
+              },
+            },
+          },
+          {
+            name: "next_cue",
+            description: "Advance to the next cue in the currently playing cue list",
+            inputSchema: {
+              type: "object",
+              properties: {
+                fadeInTime: {
+                  type: "number",
+                  description: "Override fade in time in seconds (optional)",
+                },
+              },
+            },
+          },
+          {
+            name: "previous_cue",
+            description: "Go back to the previous cue in the currently playing cue list",
+            inputSchema: {
+              type: "object",
+              properties: {
+                fadeInTime: {
+                  type: "number",
+                  description: "Override fade in time in seconds (optional)",
+                },
+              },
+            },
+          },
+          {
+            name: "go_to_cue",
+            description: "Jump to a specific cue by number or name in the currently playing cue list",
+            inputSchema: {
+              type: "object",
+              properties: {
+                cueNumber: {
+                  type: "number",
+                  description: "Cue number to jump to",
+                },
+                cueName: {
+                  type: "string",
+                  description: "Cue name to search for (alternative to cueNumber)",
+                },
+                fadeInTime: {
+                  type: "number",
+                  description: "Override fade in time in seconds (optional)",
+                },
+              },
+            },
+          },
+          {
+            name: "stop_cue_list",
+            description: "Stop the currently playing cue list",
+            inputSchema: {
+              type: "object",
+              properties: {},
+            },
+          },
+          {
+            name: "get_cue_list_status",
+            description: "Get information about the currently playing cue list and navigation options",
+            inputSchema: {
+              type: "object",
+              properties: {},
+            },
+          },
         ],
       };
     });
@@ -1173,6 +1309,48 @@ class LacyLightsMCPServer {
               ],
             };
 
+          case "activate_scene":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.sceneTools.activateScene(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "fade_to_black":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.sceneTools.fadeToBlack(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "get_current_active_scene":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.sceneTools.getCurrentActiveScene(),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
           // Cue Tools
           case "create_cue_sequence":
             return {
@@ -1322,6 +1500,91 @@ class LacyLightsMCPServer {
                   type: "text",
                   text: JSON.stringify(
                     await this.cueTools.deleteCueList(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          // Cue List Playback Tools
+          case "start_cue_list":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.cueTools.startCueList(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "next_cue":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.cueTools.nextCue(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "previous_cue":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.cueTools.previousCue(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "go_to_cue":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.cueTools.goToCue(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "stop_cue_list":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.cueTools.stopCueList(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "get_cue_list_status":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.cueTools.getCueListStatus(args as any),
                     null,
                     2,
                   ),

--- a/src/services/graphql-client-simple.ts
+++ b/src/services/graphql-client-simple.ts
@@ -648,4 +648,117 @@ export class LacyLightsGraphQLClient {
     const data = await this.query(mutation, { id });
     return data.deleteFixtureInstance;
   }
+
+  async setSceneLive(sceneId: string): Promise<boolean> {
+    const mutation = `
+      mutation ActivateScene($sceneId: ID!) {
+        setSceneLive(sceneId: $sceneId)
+      }
+    `;
+
+    const data = await this.query(mutation, { sceneId });
+    return data.setSceneLive;
+  }
+
+  async fadeToBlack(fadeOutTime: number): Promise<boolean> {
+    const mutation = `
+      mutation FadeToBlack($fadeOutTime: Float!) {
+        fadeToBlack(fadeOutTime: $fadeOutTime)
+      }
+    `;
+
+    const data = await this.query(mutation, { fadeOutTime });
+    return data.fadeToBlack;
+  }
+
+  async getScene(id: string): Promise<Scene | null> {
+    const query = `
+      query GetScene($id: ID!) {
+        scene(id: $id) {
+          id
+          name
+          description
+          createdAt
+          updatedAt
+          fixtureValues {
+            fixture {
+              id
+              name
+            }
+            channelValues
+          }
+        }
+      }
+    `;
+
+    const data = await this.query(query, { id });
+    return data.scene;
+  }
+
+  async getCurrentActiveScene(): Promise<Scene | null> {
+    const query = `
+      query GetCurrentActiveScene {
+        currentActiveScene {
+          id
+          name
+          description
+          createdAt
+          updatedAt
+          project {
+            id
+            name
+          }
+          fixtureValues {
+            fixture {
+              id
+              name
+            }
+            channelValues
+          }
+        }
+      }
+    `;
+
+    const data = await this.query(query);
+    return data.currentActiveScene;
+  }
+
+  async getCue(id: string): Promise<Cue | null> {
+    const query = `
+      query GetCue($id: ID!) {
+        cue(id: $id) {
+          id
+          name
+          cueNumber
+          fadeInTime
+          fadeOutTime
+          followTime
+          notes
+          cueList {
+            id
+            name
+          }
+          scene {
+            id
+            name
+            description
+          }
+        }
+      }
+    `;
+
+    const data = await this.query(query, { id });
+    return data.cue;
+  }
+
+  async playCue(cueId: string, fadeInTime?: number): Promise<boolean> {
+    const mutation = `
+      mutation PlayCue($cueId: ID!, $fadeInTime: Float) {
+        playCue(cueId: $cueId, fadeInTime: $fadeInTime)
+      }
+    `;
+
+    const data = await this.query(mutation, { cueId, fadeInTime });
+    return data.playCue;
+  }
 }

--- a/src/tools/cue-tools.ts
+++ b/src/tools/cue-tools.ts
@@ -85,6 +85,11 @@ interface CueListPlaybackState {
 }
 
 export class CueTools {
+  // KNOWN LIMITATION: This instance-level playback state could cause issues in concurrent 
+  // environments where multiple cue list operations might interfere with each other.
+  // TODO: Future improvement should use a static map with cueListId as key:
+  // private static playbackStates: Map<string, CueListPlaybackState> = new Map();
+  // This would allow multiple concurrent cue list playback sessions.
   private playbackState: CueListPlaybackState | null = null;
 
   constructor(

--- a/src/tools/cue-tools.ts
+++ b/src/tools/cue-tools.ts
@@ -1168,7 +1168,7 @@ export class CueTools {
 
       // Play the first cue
       const firstCue = this.playbackState.cues[startIndex];
-      await this.graphqlClient.playCue(firstCue.id);
+      await this.graphqlClient.playCue(firstCue.id, firstCue.fadeInTime);
 
       return {
         success: true,
@@ -1295,9 +1295,10 @@ export class CueTools {
       throw new Error('Either cueNumber or cueName must be provided');
     }
 
-    try {
-      let targetIndex = -1;
+    let targetIndex = -1;
+    let oldIndex = this.playbackState.currentCueIndex;
 
+    try {
       if (cueNumber !== undefined) {
         targetIndex = this.playbackState.cues.findIndex(cue => cue.cueNumber === cueNumber);
       } else if (cueName) {
@@ -1311,8 +1312,6 @@ export class CueTools {
         const searchTerm = cueNumber !== undefined ? `number ${cueNumber}` : `name "${cueName}"`;
         throw new Error(`Cue with ${searchTerm} not found in current cue list`);
       }
-
-      const oldIndex = this.playbackState.currentCueIndex;
       this.playbackState.currentCueIndex = targetIndex;
       const targetCue = this.playbackState.cues[targetIndex];
       
@@ -1337,6 +1336,8 @@ export class CueTools {
         message: `Jumped to cue ${targetCue.cueNumber} - "${targetCue.name}"`
       };
     } catch (error) {
+      // Revert the index change if the cue failed to play
+      this.playbackState.currentCueIndex = oldIndex;
       throw new Error(`Failed to go to cue: ${error}`);
     }
   }

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -500,15 +500,20 @@ export class SceneTools {
         throw new Error('Either sceneId or sceneName must be provided');
       }
 
+      // Ensure resolvedSceneId is defined before using it
+      if (!resolvedSceneId) {
+        throw new Error('Resolved scene ID is undefined');
+      }
+
       // Activate the scene
-      const success = await this.graphqlClient.setSceneLive(resolvedSceneId!);
+      const success = await this.graphqlClient.setSceneLive(resolvedSceneId);
       
       if (!success) {
         throw new Error('Failed to activate scene');
       }
 
       // Get scene details for response
-      const scene = await this.graphqlClient.getScene(resolvedSceneId!);
+      const scene = await this.graphqlClient.getScene(resolvedSceneId);
       
       return {
         success: true,

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -515,15 +515,19 @@ export class SceneTools {
       // Get scene details for response
       const scene = await this.graphqlClient.getScene(resolvedSceneId);
       
+      if (!scene) {
+        throw new Error('Scene could not be retrieved after activation');
+      }
+      
       return {
         success: true,
         scene: {
-          id: scene!.id,
-          name: scene!.name,
-          description: scene!.description
+          id: scene.id,
+          name: scene.name,
+          description: scene.description
         },
-        message: `Scene "${scene!.name}" is now active`,
-        fixturesActive: scene!.fixtureValues.length,
+        message: `Scene "${scene.name}" is now active`,
+        fixturesActive: scene.fixtureValues.length,
         hint: 'Use fade_to_black to turn off all lights'
       };
     } catch (error) {


### PR DESCRIPTION
## Summary
This PR introduces major enhancements to the MCP server enabling direct scene activation and complete cue list playback control through natural language commands, replacing complex preview workflows with simpler activation patterns.

## Scene Activation Features

### Enhanced Scene Control
- **Replace preview_scene with activate_scene**: Simplified scene activation using setSceneLive GraphQL mutation
- **Add fade_to_black tool**: Direct control to fade all lights with configurable timing  
- **Add get_current_active_scene tool**: Query which scene is currently active
- **Enhanced generate_scene**: Add optional `activate` parameter to automatically activate generated scenes
- **Smart scene search**: Find scenes by name across projects with fuzzy matching

## Cue List Playback System

### Complete Playback Control
- **start_cue_list**: Begin playback from any cue, search by name or ID across projects
- **next_cue / previous_cue**: Navigate through cues with proper fade timing and boundary checking
- **go_to_cue**: Jump to specific cue by number or name with fuzzy matching  
- **stop_cue_list**: End playback session and clear state tracking
- **get_cue_list_status**: Comprehensive status including navigation options and timing

### Advanced Features
- **Intelligent cue sorting**: Automatic ordering by cue number for proper sequence
- **Fade time management**: Respect cue fade times or accept manual overrides
- **Error handling with rollback**: Failed cue changes revert playback position  
- **Navigation boundaries**: Prevent advancing past first/last cues with clear feedback
- **Rich status reporting**: Current cue details, navigation options, and session timing

## Usage Examples
Users can now interact with:
- "Activate scene named Sunset" → `activate_scene` with scene name search
- "Start playing Act 1 cue list" → `start_cue_list` with name-based search  
- "Go to next cue" → `next_cue` with proper fade timing
- "Jump to cue 7" → `go_to_cue` with number-based navigation
- "What scene is active?" → `get_current_active_scene` status query
- "Turn off all lights" → `fade_to_black` with timing control

## Technical Benefits
- **Simplified workflow**: Direct activation replaces complex preview session management
- **Stateful playback**: Maintains cue list position and navigation context
- **Natural language ready**: Tools designed for AI/LLM interaction patterns
- **Comprehensive error handling**: Graceful failures with informative messages
- **Performance optimized**: Efficient GraphQL queries and state management

## Test Plan
- [x] All new tools registered and functional
- [x] Scene activation works with both ID and name-based search
- [x] Cue list playback maintains proper state and navigation
- [x] Error handling prevents invalid states and provides clear feedback
- [x] Integration with existing GraphQL mutations and queries

🤖 Generated with [Claude Code](https://claude.ai/code)