### PR TITLE
Fix MCP server to use backend's centralized playback state

### DIFF
--- a/src/services/graphql-client-simple.ts
+++ b/src/services/graphql-client-simple.ts
@@ -887,6 +887,86 @@ export class LacyLightsGraphQLClient {
     return data.playCue;
   }
 
+  async getCueListPlaybackStatus(cueListId: string): Promise<any> {
+    const query = `
+      query GetCueListPlaybackStatus($cueListId: ID!) {
+        cueListPlaybackStatus(cueListId: $cueListId) {
+          cueListId
+          currentCueIndex
+          isPlaying
+          currentCue {
+            id
+            name
+            cueNumber
+            fadeInTime
+            fadeOutTime
+            followTime
+          }
+          fadeProgress
+          lastUpdated
+        }
+      }
+    `;
+
+    const data = await this.query(query, { cueListId });
+    return data.cueListPlaybackStatus;
+  }
+
+  async startCueList(cueListId: string, startFromCue?: number): Promise<boolean> {
+    const mutation = `
+      mutation StartCueList($cueListId: ID!, $startFromCue: Int) {
+        startCueList(cueListId: $cueListId, startFromCue: $startFromCue)
+      }
+    `;
+
+    const data = await this.query(mutation, { cueListId, startFromCue });
+    return data.startCueList;
+  }
+
+  async nextCue(cueListId: string, fadeInTime?: number): Promise<boolean> {
+    const mutation = `
+      mutation NextCue($cueListId: ID!, $fadeInTime: Float) {
+        nextCue(cueListId: $cueListId, fadeInTime: $fadeInTime)
+      }
+    `;
+
+    const data = await this.query(mutation, { cueListId, fadeInTime });
+    return data.nextCue;
+  }
+
+  async previousCue(cueListId: string, fadeInTime?: number): Promise<boolean> {
+    const mutation = `
+      mutation PreviousCue($cueListId: ID!, $fadeInTime: Float) {
+        previousCue(cueListId: $cueListId, fadeInTime: $fadeInTime)
+      }
+    `;
+
+    const data = await this.query(mutation, { cueListId, fadeInTime });
+    return data.previousCue;
+  }
+
+  async goToCue(cueListId: string, cueIndex: number, fadeInTime?: number): Promise<boolean> {
+    const mutation = `
+      mutation GoToCue($cueListId: ID!, $cueIndex: Int!, $fadeInTime: Float) {
+        goToCue(cueListId: $cueListId, cueIndex: $cueIndex, fadeInTime: $fadeInTime)
+      }
+    `;
+
+    const data = await this.query(mutation, { cueListId, cueIndex, fadeInTime });
+    return data.goToCue;
+  }
+
+  async stopCueList(cueListId: string): Promise<boolean> {
+    const mutation = `
+      mutation StopCueList($cueListId: ID!) {
+        stopCueList(cueListId: $cueListId)
+      }
+    `;
+
+    const data = await this.query(mutation, { cueListId });
+    return data.stopCueList;
+  }
+
   // importProjectFromQLC method removed - import functionality moved to web UI due to file size constraints
   // async importProjectFromQLC(xmlContent: string, originalFileName: string): Promise<any> {
     /*const mutation = `


### PR DESCRIPTION
## Summary

This PR fixes the issue where the MCP server maintained its own separate playback state instead of using the backend's centralized state management.

### Problem

In the current implementation:
1. MCP server tracked playback state locally in `this.playbackState`
2. Frontend used backend's centralized `playbackStateService`
3. When frontend advanced cues, backend state updated but MCP state remained out of sync
4. MCP "next cue" commands used stale local state instead of current backend state

### Solution

- **Added new GraphQL mutations and query** to backend for centralized playback control
- **Replaced MCP local state** with backend state queries
- **Updated all playback methods** to use backend mutations and query current status
- **Removed local `CueListPlaybackState`** interface and tracking

### Key Changes

#### Backend (lacylights-node)
- Added `cueListPlaybackStatus` query to get current playback state
- Added `startCueList`, `nextCue`, `previousCue`, `goToCue`, `stopCueList` mutations
- All mutations use the centralized `playbackStateService`

#### MCP Server (lacylights-mcp)  
- Added new GraphQL client methods for playback control
- Replaced `private playbackState` with `private activeCueLists: Set<string>`
- Updated all methods to use backend mutations and query status

### Benefits

✅ **Single source of truth** - All clients use same backend state  
✅ **Real-time synchronization** - MCP and frontend stay in sync  
✅ **Consistent behavior** - Next/previous commands work from any client  
✅ **No state conflicts** - Eliminates race conditions and desync issues  

### Test Scenario

The original issue is now resolved:

1. **mcp: go to cue 9** → Backend sets channels to cue 9, all clients see cue 9
2. **fe: click go button 3 times** → Backend advances to cue 12, all clients see cue 12  
3. **mcp: next cue** → Backend advances to cue 13 (not cue 10), all clients see cue 13

🤖 Generated with [Claude Code](https://claude.ai/code)