### PR TITLE
feat: Add file-based logging for MCP server debugging

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,0 +1,200 @@
+# Debugging the LacyLights MCP Server
+
+## Overview
+
+The LacyLights MCP server now includes file-based logging to help debug issues when the server is called from Claude Desktop or other MCP clients. Since the MCP protocol uses stdio (standard input/output) for communication, we cannot use console.log for debugging—instead, all logs are written to a file.
+
+## Log File Location
+
+Logs are written to:
+```
+~/.lacylights-mcp/logs/mcp-server.log
+```
+
+On macOS/Linux, this is typically:
+```
+/Users/YOUR_USERNAME/.lacylights-mcp/logs/mcp-server.log
+```
+
+On Windows, this would be:
+```
+C:\Users\YOUR_USERNAME\.lacylights-mcp\logs\mcp-server.log
+```
+
+## Viewing Logs in Real-Time
+
+To watch the logs as they are written (useful when debugging):
+
+### macOS/Linux:
+```bash
+tail -f ~/.lacylights-mcp/logs/mcp-server.log
+```
+
+### Or use less for scrolling:
+```bash
+less +F ~/.lacylights-mcp/logs/mcp-server.log
+```
+(Press Ctrl+C to stop following, then 'q' to quit)
+
+## What Gets Logged
+
+The MCP server logs the following information:
+
+1. **Server Startup**: When the server starts, including the log file path and GraphQL endpoint
+2. **All Tool Calls**: Every MCP tool invocation with its arguments
+3. **Errors**: Any errors that occur, including full stack traces
+4. **Fixture Updates**: Detailed logging for fixture update operations, including:
+   - Fixture IDs being updated
+   - Current fixture information
+   - Update data being sent to the backend
+   - Success/failure status
+
+## Log Levels
+
+The logger uses four levels:
+- `INFO`: General information (server startup, successful operations)
+- `DEBUG`: Detailed debugging information (function calls, intermediate states)
+- `WARN`: Warning messages (optional features that failed to initialize)
+- `ERROR`: Error messages with stack traces
+
+## Log Format
+
+Each log entry follows this format:
+```
+[2025-10-05T12:34:56.789Z] [LEVEL] Message
+{
+  "additional": "data",
+  "in": "JSON format"
+}
+```
+
+## Debugging Fixture Rename Issues
+
+When Claude Desktop tries to rename fixtures (like your "par X" naming issue), you'll see entries like:
+
+```
+[2025-10-05T12:34:56.789Z] [INFO] Tool call: update_fixture_instance
+{
+  "args": {
+    "fixtureId": "fixture-123",
+    "name": "par 1"
+  }
+}
+
+[2025-10-05T12:34:56.890Z] [DEBUG] updateFixtureInstance called
+{
+  "fixtureId": "fixture-123",
+  "name": "par 1"
+}
+
+[2025-10-05T12:34:56.950Z] [DEBUG] Found current fixture
+{
+  "id": "fixture-123",
+  "name": "LED Par 1",
+  "manufacturer": "Chauvet",
+  "model": "SlimPAR 64"
+}
+
+[2025-10-05T12:34:57.100Z] [DEBUG] Calling GraphQL updateFixtureInstance
+{
+  "fixtureId": "fixture-123",
+  "updateData": {
+    "name": "par 1"
+  }
+}
+
+[2025-10-05T12:34:57.250Z] [INFO] Fixture updated successfully
+{
+  "id": "fixture-123",
+  "name": "par 1"
+}
+```
+
+If there's an error, you'll see:
+```
+[2025-10-05T12:34:57.250Z] [ERROR] Tool call failed: update_fixture_instance
+{
+  "args": {
+    "fixtureId": "fixture-123",
+    "name": "par 1"
+  },
+  "error": "GraphQL error: Invalid fixture ID",
+  "stack": "Error: GraphQL error: Invalid fixture ID\n    at ..."
+}
+```
+
+## Log Rotation
+
+The log file automatically rotates when it exceeds 10MB. Old logs are renamed with a timestamp:
+```
+mcp-server-2025-10-05T12-34-56-789Z.log
+```
+
+## Reproducing Your Issue
+
+To debug the fixture renaming issue:
+
+1. **Start watching the logs**:
+   ```bash
+   tail -f ~/.lacylights-mcp/logs/mcp-server.log
+   ```
+
+2. **Clear the current log** (optional, to start fresh):
+   ```bash
+   > ~/.lacylights-mcp/logs/mcp-server.log
+   ```
+
+3. **Restart Claude Desktop** to ensure the MCP server restarts with logging
+
+4. **Execute your prompt** in Claude Desktop:
+   ```
+   Working with lacylights, I'm working on project "test" which has 10 fixtures
+   defined so far. Rename them "par X" where X is the index (starting with 1)
+   of the sequential list of par fixtures.
+   ```
+
+5. **Watch the logs** to see exactly which MCP calls are being made and where failures occur
+
+## Common Issues and What to Look For
+
+### Fixture Not Found
+```
+[ERROR] Fixture not found
+{
+  "fixtureId": "some-id"
+}
+```
+This means Claude is passing an invalid fixture ID. Check if the fixture exists in the project.
+
+### GraphQL Errors
+```
+[ERROR] Tool call failed: update_fixture_instance
+{
+  "error": "GraphQL error: ...",
+  "stack": "..."
+}
+```
+This indicates a backend API issue. The error message will tell you what went wrong on the backend.
+
+### Network/Connection Issues
+```
+[ERROR] Failed to update fixture instance
+{
+  "error": "fetch failed",
+  "stack": "..."
+}
+```
+This suggests the MCP server can't connect to the lacylights-node backend. Ensure the backend is running on http://localhost:4000.
+
+## Getting Help
+
+When reporting issues, please include:
+1. The relevant section of the log file showing the error
+2. The exact prompt you gave to Claude Desktop
+3. The state of your project (number of fixtures, their current names, etc.)
+
+You can share logs by running:
+```bash
+# Get the last 100 lines of the log
+tail -n 100 ~/.lacylights-mcp/logs/mcp-server.log
+```

--- a/src/tools/fixture-tools.ts
+++ b/src/tools/fixture-tools.ts
@@ -1005,17 +1005,19 @@ export class FixtureTools {
       tags,
     } = UpdateFixtureInstanceSchema.parse(args);
 
-    logger.debug('updateFixtureInstance called', {
-      fixtureId,
-      name,
-      description,
-      manufacturer,
-      model,
-      mode,
-      universe,
-      startChannel,
-      tags,
-    });
+    if (logger.isDebugEnabled && logger.isDebugEnabled()) {
+      logger.debug('updateFixtureInstance called', {
+        fixtureId,
+        name,
+        description,
+        manufacturer,
+        model,
+        mode,
+        universe,
+        startChannel,
+        tags,
+      });
+    }
 
     try {
       // First, get the current fixture to understand what we're updating

--- a/src/tools/fixture-tools.ts
+++ b/src/tools/fixture-tools.ts
@@ -1005,19 +1005,17 @@ export class FixtureTools {
       tags,
     } = UpdateFixtureInstanceSchema.parse(args);
 
-    if (logger.isDebugEnabled && logger.isDebugEnabled()) {
-      logger.debug('updateFixtureInstance called', {
-        fixtureId,
-        name,
-        description,
-        manufacturer,
-        model,
-        mode,
-        universe,
-        startChannel,
-        tags,
-      });
-    }
+    logger.debug('updateFixtureInstance called', {
+      fixtureId,
+      name,
+      description,
+      manufacturer,
+      model,
+      mode,
+      universe,
+      startChannel,
+      tags,
+    });
 
     try {
       // First, get the current fixture to understand what we're updating

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Simple file-based logger for MCP server debugging
+ * Logs are written to ~/.lacylights-mcp/logs/mcp-server.log
+ *
+ * This is necessary because MCP uses stdio for communication,
+ * so console.log/error would interfere with the protocol.
+ */
+class FileLogger {
+  private logFilePath: string;
+  private enabled: boolean;
+
+  constructor() {
+    // Create logs directory in user's home
+    const logsDir = path.join(os.homedir(), '.lacylights-mcp', 'logs');
+
+    try {
+      if (!fs.existsSync(logsDir)) {
+        fs.mkdirSync(logsDir, { recursive: true });
+      }
+
+      this.logFilePath = path.join(logsDir, 'mcp-server.log');
+      this.enabled = true;
+
+      // Log rotation: if file is > 10MB, rename it and start fresh
+      try {
+        const stats = fs.statSync(this.logFilePath);
+        if (stats.size > 10 * 1024 * 1024) {
+          const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+          const archivePath = path.join(logsDir, `mcp-server-${timestamp}.log`);
+          fs.renameSync(this.logFilePath, archivePath);
+        }
+      } catch {
+        // File doesn't exist yet, that's fine
+      }
+
+      this.log('info', '=== MCP Server Started ===');
+    } catch {
+      // If we can't create the log file, disable logging
+      this.enabled = false;
+      this.logFilePath = '';
+    }
+  }
+
+  private formatMessage(level: string, message: string, data?: any): string {
+    const timestamp = new Date().toISOString();
+    let formatted = `[${timestamp}] [${level.toUpperCase()}] ${message}`;
+
+    if (data !== undefined) {
+      try {
+        formatted += '\n' + JSON.stringify(data, null, 2);
+      } catch {
+        formatted += '\n[Unable to stringify data]';
+      }
+    }
+
+    return formatted + '\n';
+  }
+
+  private write(message: string): void {
+    if (!this.enabled) return;
+
+    try {
+      fs.appendFileSync(this.logFilePath, message, 'utf8');
+    } catch {
+      // If write fails, disable logging to avoid errors
+      this.enabled = false;
+    }
+  }
+
+  log(level: 'info' | 'warn' | 'error' | 'debug', message: string, data?: any): void {
+    this.write(this.formatMessage(level, message, data));
+  }
+
+  info(message: string, data?: any): void {
+    this.log('info', message, data);
+  }
+
+  warn(message: string, data?: any): void {
+    this.log('warn', message, data);
+  }
+
+  error(message: string, data?: any): void {
+    this.log('error', message, data);
+  }
+
+  debug(message: string, data?: any): void {
+    this.log('debug', message, data);
+  }
+
+  getLogPath(): string {
+    return this.logFilePath;
+  }
+}
+
+// Export singleton instance
+export const logger = new FileLogger();


### PR DESCRIPTION
## Summary

Adds comprehensive file-based logging to help debug MCP tool calls and errors when the server is accessed via Claude Desktop or other MCP clients. Since MCP uses stdio for communication, console.log output is not visible, making debugging nearly impossible without this feature.

## Motivation

When using the MCP server from Claude Desktop, errors and failures occur silently with no visibility into:
- Which MCP tools are being called
- What arguments are being passed
- Where failures occur
- What error messages are generated

This was discovered when attempting to debug a fixture renaming issue where the operation failed silently.

## Changes

### New Files
- **`src/utils/logger.ts`**: File-based logger that writes to `~/.lacylights-mcp/logs/mcp-server.log`
  - Automatic log rotation (10MB limit)
  - Four log levels: INFO, DEBUG, WARN, ERROR
  - JSON formatting for structured data
  
- **`DEBUGGING.md`**: Complete debugging guide
  - Log file location and access instructions
  - Real-time log monitoring commands
  - Common error patterns
  - Step-by-step debugging workflow

### Modified Files
- **`src/index.ts`**: 
  - Log all incoming MCP tool calls with arguments
  - Log all errors with full stack traces
  - Log server startup and configuration
  - Log fatal errors before exit

- **`src/tools/fixture-tools.ts`**:
  - Detailed logging for `updateFixtureInstance` operations
  - Log fixture lookup, current state, update data, and results
  - Log errors with full context

## Testing

- ✅ All 303 existing tests pass
- ✅ No regressions introduced
- ✅ Linting clean for all modified files
- ✅ Build succeeds without errors

## Usage

After merging, users can debug MCP issues by:

1. Start watching logs:
   ```bash
   tail -f ~/.lacylights-mcp/logs/mcp-server.log
   ```

2. Restart Claude Desktop (to restart MCP server)

3. Execute problematic operations

4. View detailed logs showing:
   - Every tool call with arguments
   - Success/failure status
   - Error messages and stack traces
   - Intermediate states during operations

## Example Log Output

```
[2025-10-05T...] [INFO] LacyLights MCP Server initializing
[2025-10-05T...] [INFO] Tool call: update_fixture_instance
  { "args": { "fixtureId": "...", "name": "par 1" } }
[2025-10-05T...] [DEBUG] updateFixtureInstance called
[2025-10-05T...] [DEBUG] Found current fixture
  { "id": "...", "name": "LED Par 1" }
[2025-10-05T...] [DEBUG] Calling GraphQL updateFixtureInstance
[2025-10-05T...] [INFO] Fixture updated successfully
```

## Breaking Changes

None - this is purely additive functionality.

## Future Improvements

- Add configurable log levels via environment variable
- Add log file path configuration
- Add log aggregation for production deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)