### PR TITLE
Add loop support to MCP server for cue list management

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -950,6 +950,10 @@ class LacyLightsMCPServer {
                   type: "string",
                   description: "New description for the cue list",
                 },
+                loop: {
+                  type: "boolean",
+                  description: "Whether to loop the cue list (restart from first cue after last cue finishes)",
+                },
               },
               required: ["cueListId"],
             },

--- a/src/services/graphql-client-simple.ts
+++ b/src/services/graphql-client-simple.ts
@@ -448,6 +448,7 @@ export class LacyLightsGraphQLClient {
   async updateCueList(id: string, input: {
     name?: string;
     description?: string;
+    loop?: boolean;
   }): Promise<CueList> {
     const mutation = `
       mutation UpdateCueList($id: ID!, $input: CreateCueListInput!) {
@@ -455,6 +456,7 @@ export class LacyLightsGraphQLClient {
           id
           name
           description
+          loop
           createdAt
           updatedAt
           cues {
@@ -480,6 +482,8 @@ export class LacyLightsGraphQLClient {
       query GetCueList($id: ID!) {
         cueList(id: $id) {
           id
+          name
+          loop
           project {
             id
           }
@@ -489,10 +493,11 @@ export class LacyLightsGraphQLClient {
     
     const cueListData = await this.query(cueListQuery, { id });
     const projectId = cueListData.cueList.project.id;
-    
+
     const updateInput = {
       name: input.name || cueListData.cueList.name,
       description: input.description,
+      loop: input.loop !== undefined ? input.loop : cueListData.cueList.loop,
       projectId
     };
 

--- a/src/tools/cue-tools.ts
+++ b/src/tools/cue-tools.ts
@@ -787,19 +787,21 @@ export class CueTools {
     cueListId: string;
     name?: string;
     description?: string;
+    loop?: boolean;
   }) {
-    const { cueListId, name, description } = args;
+    const { cueListId, name, description, loop } = args;
 
     try {
-      if (!name && !description) {
+      if (!name && !description && loop === undefined) {
         throw new Error(
-          "At least one field (name or description) must be provided",
+          "At least one field (name, description, or loop) must be provided",
         );
       }
 
       const updatedCueList = await this.graphqlClient.updateCueList(cueListId, {
         name,
         description,
+        loop,
       });
 
       return {
@@ -807,6 +809,7 @@ export class CueTools {
         cueList: {
           name: updatedCueList.name,
           description: updatedCueList.description,
+          loop: updatedCueList.loop,
           totalCues: updatedCueList.cues.length,
         },
         success: true,

--- a/src/types/lighting.ts
+++ b/src/types/lighting.ts
@@ -94,6 +94,7 @@ export interface CueList {
   id: string;
   name: string;
   description?: string;
+  loop: boolean;
   cues: Cue[];
 }
 

--- a/tests/tools/project-tools.test.ts
+++ b/tests/tools/project-tools.test.ts
@@ -59,6 +59,7 @@ describe('ProjectTools', () => {
         id: 'cuelist-1',
         name: 'Test Cue List',
         description: 'Test cue list description',
+        loop: false,
         cues: []
       }
     ]


### PR DESCRIPTION
## Summary
- Added loop parameter support to MCP server for cue list management
- Updated GraphQL client to include loop field in queries and mutations
- Updated cue tools to accept and pass loop parameter
- Updated MCP tool registration to expose loop parameter
- Updated TypeScript types to include loop field in CueList interface

## Test plan
- [x] All unit tests passing (303 tests)
- [x] Build successful with no TypeScript errors
- [x] Linter clean with no warnings or errors
- [x] Mock data updated to include loop field

## Technical Details
This PR completes the full-stack loop functionality by adding MCP server support. The loop parameter allows AI assistants to enable/disable loop mode for cue lists, which makes the cue list automatically restart from the first cue after the last cue finishes.

Changes include:
- `src/services/graphql-client-simple.ts`: Added loop parameter to updateCueList method
- `src/tools/cue-tools.ts`: Updated updateCueList to accept and pass loop parameter
- `src/index.ts`: Added loop parameter to MCP tool schema
- `src/types/lighting.ts`: Added loop field to CueList interface
- `tests/tools/project-tools.test.ts`: Fixed mock data to include loop field

🤖 Generated with [Claude Code](https://claude.com/claude-code)