### PR TITLE
Add GitHub Actions workflow for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,32 +86,52 @@ jobs:
 
       - name: Commit version bump
         run: |
+          set -e
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }}"
           git push
 
       - name: Create Git tag
         run: |
+          set -e
           git tag -a "v${{ steps.new_version.outputs.version }}" -m "Release v${{ steps.new_version.outputs.version }}"
           git push origin "v${{ steps.new_version.outputs.version }}"
 
       - name: Determine release name
         id: release_name
         run: |
-          if [ -n "${{ inputs.release_name }}" ]; then
-            echo "name=${{ inputs.release_name }}" >> $GITHUB_OUTPUT
-          else
+          if [ -z "${{ inputs.release_name }}" ]; then
             echo "name=v${{ steps.new_version.outputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "name=${{ inputs.release_name }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Create GitHub Release
         uses: actions/github-script@v7
         with:
           script: |
+            const tagName = 'v${{ steps.new_version.outputs.version }}';
+
+            // Check if release already exists
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName
+              });
+              core.info(`Release ${tagName} already exists. Skipping creation.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            // Create the release
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: 'v${{ steps.new_version.outputs.version }}',
+              tag_name: tagName,
               name: '${{ steps.release_name.outputs.name }}',
               draft: false,
               prerelease: false,


### PR DESCRIPTION
See https://github.com/bbernstein/lacylights-node/pull/37 for full details.

This PR adds the same automated release workflow to lacylights-mcp, enabling consistent version management across all LacyLights repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)