### PR TITLE
Fix: Use RELEASE_TOKEN to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Updates the release workflow to use `RELEASE_TOKEN` instead of `GITHUB_TOKEN` to bypass branch protection rules.

## Problem

The release workflow was failing with this error:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution

- Changed checkout action to use `secrets.RELEASE_TOKEN` (a PAT with admin permissions)
- This allows the automated workflow to commit version bumps directly to main
- Branch protection rules remain active for manual commits

## Testing

After merging this PR, the release workflow will be able to:
1. Commit version bumps to main
2. Create git tags
3. Generate GitHub releases

## Related

This fix is being applied across all LacyLights repositories:
- lacylights-mcp (this PR)
- lacylights-fe
- lacylights-node
- lacylights (launcher)