### PR TITLE
feat: generate versions.json index in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,10 +509,19 @@ jobs:
               fileSize: (.fileSize.N | tonumber)
             }) |
             # Add numeric semver components for proper semantic version sorting
-            map(. + { _v: (.version | split(".") | map(tonumber // 0)) }) |
-            # Sort: stable versions first (by semantic version desc), then prereleases
-            (map(select(.isPrerelease | not)) | sort_by(._v) | reverse) +
-            (map(select(.isPrerelease)) | sort_by(._v) | reverse) |
+            # Split version on "." and "-" to handle both base version and prerelease suffix
+            map(. + {
+              _v: (
+                .version | split("-")[0] | split(".") | map(tonumber)
+              )
+            }) |
+            # Sort: stable versions first (by semantic version desc), then prereleases (by semantic version desc)
+            (
+              map(select(.isPrerelease | not)) | sort_by(._v) | reverse
+            ) +
+            (
+              map(select(.isPrerelease)) | sort_by(._v) | reverse
+            ) |
             # Remove temporary sort key
             map(del(._v))
           ' > versions.json


### PR DESCRIPTION
## Summary
- Update release workflow to generate `versions.json` index file on distribution server
- Query DynamoDB for all released versions after each release
- Upload to S3 for frontend to query available versions without GitHub API

## Changes
1. **Release Workflow**: Added step to generate and upload `versions.json`
2. Supports version selection UI in frontend

## Test plan
- [ ] Manually trigger release or wait for next release
- [ ] Verify `versions.json` is created at `dist.lacylights.com/lacylights-mcp/versions.json`
- [ ] Verify JSON contains version and isPrerelease fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)