### PR TITLE
chore: consolidate dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^4.0.10",
-        "@modelcontextprotocol/sdk": "^1.22.0",
+        "@modelcontextprotocol/sdk": "^1.25.1",
         "cross-fetch": "^4.1.0",
-        "graphql": "^16.9.0",
-        "openai": "^6.7.0",
+        "graphql": "^16.12.0",
+        "openai": "^6.15.0",
         "zod": "^4.2.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.38.0",
+        "@eslint/js": "^9.39.2",
         "@graphql-codegen/cli": "^6.1.0",
-        "@graphql-codegen/typescript": "^5.0.6",
+        "@graphql-codegen/typescript": "^5.0.7",
         "@graphql-codegen/typescript-operations": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.10.4",
@@ -1334,9 +1334,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1799,15 +1799,15 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typescript": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.6.tgz",
-      "integrity": "sha512-rKW3wYInAnmO/DmKjhW3/KLMxUauUCZuMEPQmuoHChnwIuMjn5kVXCdArGyQqv+vVtFj55aS+sJLN4MPNNjSNg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.7.tgz",
+      "integrity": "sha512-kZwcu9Iat5RWXxLGPnDbG6qVbGTigF25/aGqCG/DCQ1Al8RufSjVXhIOkJBp7QWAqXn3AupHXL1WTMXP7xs4dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^6.1.0",
         "@graphql-codegen/schema-ast": "^5.0.0",
-        "@graphql-codegen/visitor-plugin-common": "6.2.1",
+        "@graphql-codegen/visitor-plugin-common": "6.2.2",
         "auto-bind": "~4.0.0",
         "tslib": "~2.6.0"
       },
@@ -1877,9 +1877,9 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.1.tgz",
-      "integrity": "sha512-5QT1hCV3286mrmoIC7vlFXsTlwELMexhuFIkjh+oVGGL1E8hxkIPAU0kfH/lsPbQHKi8zKmic2pl3tAdyYxNyg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.2.tgz",
+      "integrity": "sha512-wEJ4zJj58PKlXISItZfr0xIHyM1lAuRfoflPegsb1L17Mx5+YzNOy0WAlLele3yzyV89WvCiprFKMcVQ7KfDXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2537,6 +2537,18 @@
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
+      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4589,11 +4601,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
-      "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
+      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -4604,6 +4617,7 @@
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
@@ -6838,6 +6852,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -7633,9 +7660,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -7811,6 +7838,16 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.1.tgz",
+      "integrity": "sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-escaper": {
@@ -10402,6 +10439,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11217,9 +11260,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.8.1.tgz",
-      "integrity": "sha512-ACifslrVgf+maMz9vqwMP4+v9qvx5Yzssydizks8n+YUJ6YwUoxj51sKRQ8HYMfR6wgKLSIlaI108ZwCk+8yig==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.15.0.tgz",
+      "integrity": "sha512-F1Lvs5BoVvmZtzkUEVyh8mDQPPFolq4F+xdsx/DO8Hee8YF3IGAlZqUIsF+DVGhqf4aU0a3bTghsxB6OIsRy1g==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
   "license": "MIT",
   "dependencies": {
     "@apollo/client": "^4.0.10",
-    "@modelcontextprotocol/sdk": "^1.22.0",
+    "@modelcontextprotocol/sdk": "^1.25.1",
     "cross-fetch": "^4.1.0",
-    "graphql": "^16.9.0",
-    "openai": "^6.7.0",
+    "graphql": "^16.12.0",
+    "openai": "^6.15.0",
     "zod": "^4.2.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.38.0",
+    "@eslint/js": "^9.39.2",
     "@graphql-codegen/cli": "^6.1.0",
-    "@graphql-codegen/typescript": "^5.0.6",
+    "@graphql-codegen/typescript": "^5.0.7",
     "@graphql-codegen/typescript-operations": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.4",


### PR DESCRIPTION
## Summary

Consolidates 5 dependabot dependency updates into a single PR:

| Package | From | To | PR |
|---------|------|----|----|
| @modelcontextprotocol/sdk | 1.22.0 | 1.25.1 | #123 |
| graphql | 16.9.0 | 16.12.0 | #121 |
| openai | 6.7.0 | 6.15.0 | #122 |
| @eslint/js | 9.38.0 | 9.39.2 | #124 |
| @graphql-codegen/typescript | 5.0.6 | 5.0.7 | #125 |

## Test Plan

- [x] `npm install` succeeds
- [x] `npm run lint` passes
- [x] `npm run test:node25` passes (541 tests)

After merging, close PRs #121, #122, #123, #124, #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)