### PR TITLE
deps: update zod to 4.3.5 and globals to 17.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "cross-fetch": "^4.1.0",
         "graphql": "^16.12.0",
         "openai": "^6.15.0",
-        "zod": "^4.2.0"
+        "zod": "^4.3.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -24,7 +24,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^24.10.4",
         "eslint": "^9.39.2",
-        "globals": "^16.5.0",
+        "globals": "^17.0.0",
         "jest": "^30.1.3",
         "ts-jest": "^29.4.6",
         "tsx": "^4.21.0",
@@ -7594,9 +7594,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
+      "integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13359,9 +13359,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cross-fetch": "^4.1.0",
     "graphql": "^16.12.0",
     "openai": "^6.15.0",
-    "zod": "^4.2.0"
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
@@ -42,7 +42,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.4",
     "eslint": "^9.39.2",
-    "globals": "^16.5.0",
+    "globals": "^17.0.0",
     "jest": "^30.1.3",
     "ts-jest": "^29.4.6",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary
- Bump **zod** from 4.2.1 to 4.3.5 (runtime dependency)
  - Adds `z.fromJSONSchema()` for JSON Schema conversion
  - Improves mini tree-shaking
- Bump **globals** from 16.5.0 to 17.0.0 (dev dependency)
  - Adds `bunBuiltin`, `denoBuiltin`, `paintWorklet`, `sharedWorker` environments
  - Breaking: splits `audioWorklet` environment from `browser`

Consolidates dependabot PRs #137 and #138.

## Test plan
- [x] All 552 tests pass
- [x] Lint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)