### PR TITLE
chore: Regenerate GraphQL types for FX Engine schema

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -32,6 +32,37 @@ export type ApConfig = {
   timeoutMinutes: Scalars['Int']['output'];
 };
 
+/** Status of an active effect at runtime. */
+export type ActiveEffectStatus = {
+  __typename?: 'ActiveEffectStatus';
+  effectId: Scalars['ID']['output'];
+  effectName: Scalars['String']['output'];
+  effectType: EffectType;
+  /** Current intensity (0-100) */
+  intensity: Scalars['Float']['output'];
+  /** Whether the effect has completed */
+  isComplete: Scalars['Boolean']['output'];
+  /** Current phase for waveforms (0-360) */
+  phase: Scalars['Float']['output'];
+  startTime: Scalars['String']['output'];
+};
+
+export type AddEffectToCueInput = {
+  cueId: Scalars['ID']['input'];
+  effectId: Scalars['ID']['input'];
+  intensity?: InputMaybe<Scalars['Float']['input']>;
+  onCueChange?: InputMaybe<TransitionBehavior>;
+  speed?: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type AddFixtureToEffectInput = {
+  amplitudeScale?: InputMaybe<Scalars['Float']['input']>;
+  effectId: Scalars['ID']['input'];
+  effectOrder?: InputMaybe<Scalars['Int']['input']>;
+  fixtureId: Scalars['ID']['input'];
+  phaseOffset?: InputMaybe<Scalars['Float']['input']>;
+};
+
 export type ArtNetStatus = {
   __typename?: 'ArtNetStatus';
   broadcastAddress: Scalars['String']['output'];
@@ -67,6 +98,8 @@ export type BulkCueUpdateInput = {
   fadeInTime?: InputMaybe<Scalars['Float']['input']>;
   fadeOutTime?: InputMaybe<Scalars['Float']['input']>;
   followTime?: InputMaybe<Scalars['Float']['input']>;
+  /** When set, updates the skip status of all selected cues */
+  skip?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type BulkDeleteResult = {
@@ -91,45 +124,45 @@ export type BulkFixtureUpdateInput = {
   fixtures: Array<FixtureUpdateItem>;
 };
 
+export type BulkLookBoardButtonCreateInput = {
+  buttons: Array<CreateLookBoardButtonInput>;
+};
+
+export type BulkLookBoardButtonUpdateInput = {
+  buttons: Array<LookBoardButtonUpdateItem>;
+};
+
+export type BulkLookBoardCreateInput = {
+  lookBoards: Array<CreateLookBoardInput>;
+};
+
+export type BulkLookBoardUpdateInput = {
+  lookBoards: Array<LookBoardUpdateItem>;
+};
+
+export type BulkLookCreateInput = {
+  looks: Array<CreateLookInput>;
+};
+
+/**
+ * Updates multiple looks with partial fixture value merging support.
+ * Each look can independently specify name, description, fixtureValues, and mergeFixtures.
+ * Operations are applied in order and fail on first error.
+ */
+export type BulkLookPartialUpdateInput = {
+  looks: Array<LookPartialUpdateItem>;
+};
+
+export type BulkLookUpdateInput = {
+  looks: Array<LookUpdateItem>;
+};
+
 export type BulkProjectCreateInput = {
   projects: Array<CreateProjectInput>;
 };
 
 export type BulkProjectUpdateInput = {
   projects: Array<ProjectUpdateItem>;
-};
-
-export type BulkSceneBoardButtonCreateInput = {
-  buttons: Array<CreateSceneBoardButtonInput>;
-};
-
-export type BulkSceneBoardButtonUpdateInput = {
-  buttons: Array<SceneBoardButtonUpdateItem>;
-};
-
-export type BulkSceneBoardCreateInput = {
-  sceneBoards: Array<CreateSceneBoardInput>;
-};
-
-export type BulkSceneBoardUpdateInput = {
-  sceneBoards: Array<SceneBoardUpdateItem>;
-};
-
-export type BulkSceneCreateInput = {
-  scenes: Array<CreateSceneInput>;
-};
-
-/**
- * Updates multiple scenes with partial fixture value merging support.
- * Each scene can independently specify name, description, fixtureValues, and mergeFixtures.
- * Operations are applied in order and fail on first error.
- */
-export type BulkScenePartialUpdateInput = {
-  scenes: Array<ScenePartialUpdateItem>;
-};
-
-export type BulkSceneUpdateInput = {
-  scenes: Array<SceneUpdateItem>;
 };
 
 export type ChannelAssignmentInput = {
@@ -226,6 +259,17 @@ export type ChannelValueInput = {
   value: Scalars['Int']['input'];
 };
 
+/**
+ * How multiple effects combine their values.
+ * OVERRIDE - Higher priority effect completely replaces lower
+ * ADDITIVE - Effects add their values together
+ * MULTIPLY - Effects multiply their values together
+ */
+export type CompositionMode =
+  | 'ADDITIVE'
+  | 'MULTIPLY'
+  | 'OVERRIDE';
+
 export type CreateChannelDefinitionInput = {
   defaultValue: Scalars['Int']['input'];
   fadeBehavior?: InputMaybe<FadeBehavior>;
@@ -244,9 +288,11 @@ export type CreateCueInput = {
   fadeInTime: Scalars['Float']['input'];
   fadeOutTime: Scalars['Float']['input'];
   followTime?: InputMaybe<Scalars['Float']['input']>;
+  lookId: Scalars['ID']['input'];
   name: Scalars['String']['input'];
   notes?: InputMaybe<Scalars['String']['input']>;
-  sceneId: Scalars['ID']['input'];
+  /** When true, this cue is skipped during playback (default: false) */
+  skip?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type CreateCueListInput = {
@@ -254,6 +300,24 @@ export type CreateCueListInput = {
   loop?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
   projectId: Scalars['ID']['input'];
+};
+
+export type CreateEffectInput = {
+  amplitude?: InputMaybe<Scalars['Float']['input']>;
+  compositionMode?: InputMaybe<CompositionMode>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  effectType: EffectType;
+  fadeDuration?: InputMaybe<Scalars['Float']['input']>;
+  frequency?: InputMaybe<Scalars['Float']['input']>;
+  masterValue?: InputMaybe<Scalars['Float']['input']>;
+  name: Scalars['String']['input'];
+  offset?: InputMaybe<Scalars['Float']['input']>;
+  onCueChange?: InputMaybe<TransitionBehavior>;
+  phaseOffset?: InputMaybe<Scalars['Float']['input']>;
+  priorityBand?: InputMaybe<PriorityBand>;
+  prioritySub?: InputMaybe<Scalars['Int']['input']>;
+  projectId: Scalars['ID']['input'];
+  waveform?: InputMaybe<WaveformType>;
 };
 
 export type CreateFixtureDefinitionInput = {
@@ -275,6 +339,34 @@ export type CreateFixtureInstanceInput = {
   universe: Scalars['Int']['input'];
 };
 
+export type CreateLookBoardButtonInput = {
+  color?: InputMaybe<Scalars['String']['input']>;
+  height?: InputMaybe<Scalars['Int']['input']>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  layoutX: Scalars['Int']['input'];
+  layoutY: Scalars['Int']['input'];
+  lookBoardId: Scalars['ID']['input'];
+  lookId: Scalars['ID']['input'];
+  width?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type CreateLookBoardInput = {
+  canvasHeight?: InputMaybe<Scalars['Int']['input']>;
+  canvasWidth?: InputMaybe<Scalars['Int']['input']>;
+  defaultFadeTime?: InputMaybe<Scalars['Float']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  gridSize?: InputMaybe<Scalars['Int']['input']>;
+  name: Scalars['String']['input'];
+  projectId: Scalars['ID']['input'];
+};
+
+export type CreateLookInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  fixtureValues: Array<FixtureValueInput>;
+  name: Scalars['String']['input'];
+  projectId: Scalars['ID']['input'];
+};
+
 export type CreateModeInput = {
   channels: Array<Scalars['String']['input']>;
   name: Scalars['String']['input'];
@@ -288,34 +380,6 @@ export type CreateProjectInput = {
   name: Scalars['String']['input'];
 };
 
-export type CreateSceneBoardButtonInput = {
-  color?: InputMaybe<Scalars['String']['input']>;
-  height?: InputMaybe<Scalars['Int']['input']>;
-  label?: InputMaybe<Scalars['String']['input']>;
-  layoutX: Scalars['Int']['input'];
-  layoutY: Scalars['Int']['input'];
-  sceneBoardId: Scalars['ID']['input'];
-  sceneId: Scalars['ID']['input'];
-  width?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export type CreateSceneBoardInput = {
-  canvasHeight?: InputMaybe<Scalars['Int']['input']>;
-  canvasWidth?: InputMaybe<Scalars['Int']['input']>;
-  defaultFadeTime?: InputMaybe<Scalars['Float']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  gridSize?: InputMaybe<Scalars['Int']['input']>;
-  name: Scalars['String']['input'];
-  projectId: Scalars['ID']['input'];
-};
-
-export type CreateSceneInput = {
-  description?: InputMaybe<Scalars['String']['input']>;
-  fixtureValues: Array<FixtureValueInput>;
-  name: Scalars['String']['input'];
-  projectId: Scalars['ID']['input'];
-};
-
 export type Cue = {
   __typename?: 'Cue';
   cueList: CueList;
@@ -325,9 +389,26 @@ export type Cue = {
   fadeOutTime: Scalars['Float']['output'];
   followTime?: Maybe<Scalars['Float']['output']>;
   id: Scalars['ID']['output'];
+  look: Look;
   name: Scalars['String']['output'];
   notes?: Maybe<Scalars['String']['output']>;
-  scene: Scene;
+  /** When true, this cue is skipped during playback but remains visible in the UI */
+  skip: Scalars['Boolean']['output'];
+};
+
+/** Links an effect to a cue with runtime parameters. */
+export type CueEffect = {
+  __typename?: 'CueEffect';
+  cueId: Scalars['ID']['output'];
+  effect?: Maybe<Effect>;
+  effectId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  /** Intensity override (0-100) */
+  intensity: Scalars['Float']['output'];
+  /** Override effect's default cue change behavior */
+  onCueChange?: Maybe<TransitionBehavior>;
+  /** Speed/frequency multiplier */
+  speed: Scalars['Float']['output'];
 };
 
 export type CueList = {
@@ -344,6 +425,29 @@ export type CueList = {
   updatedAt: Scalars['String']['output'];
 };
 
+export type CueListDataChangeType =
+  | 'CUE_ADDED'
+  | 'CUE_LIST_METADATA_CHANGED'
+  | 'CUE_REMOVED'
+  | 'CUE_REORDERED'
+  | 'CUE_UPDATED'
+  | 'LOOK_NAME_CHANGED';
+
+/** Payload for cue list data change notifications */
+export type CueListDataChangedPayload = {
+  __typename?: 'CueListDataChangedPayload';
+  /** Affected cue IDs (for cue changes) */
+  affectedCueIds?: Maybe<Array<Scalars['ID']['output']>>;
+  /** Affected look ID (for look name changes) */
+  affectedLookId?: Maybe<Scalars['ID']['output']>;
+  changeType: CueListDataChangeType;
+  cueListId: Scalars['ID']['output'];
+  /** New look name if this is a LOOK_NAME_CHANGED event */
+  newLookName?: Maybe<Scalars['String']['output']>;
+  /** Timestamp of the change */
+  timestamp: Scalars['String']['output'];
+};
+
 export type CueListPlaybackStatus = {
   __typename?: 'CueListPlaybackStatus';
   cueListId: Scalars['ID']['output'];
@@ -352,9 +456,9 @@ export type CueListPlaybackStatus = {
   fadeProgress?: Maybe<Scalars['Float']['output']>;
   /** True when a fade-in transition is in progress */
   isFading: Scalars['Boolean']['output'];
-  /** True when the cue list is paused (scene activated outside cue context, cue index preserved) */
+  /** True when the cue list is paused (look activated outside cue context, cue index preserved) */
   isPaused: Scalars['Boolean']['output'];
-  /** True when a scene's values are currently active on DMX fixtures (stays true after fade completes until stopped) */
+  /** True when a look's values are currently active on DMX fixtures (stays true after fade completes until stopped) */
   isPlaying: Scalars['Boolean']['output'];
   lastUpdated: Scalars['String']['output'];
   nextCue?: Maybe<Cue>;
@@ -400,8 +504,8 @@ export type CueUsageSummary = {
 };
 
 export type DifferenceType =
-  | 'ONLY_IN_SCENE1'
-  | 'ONLY_IN_SCENE2'
+  | 'ONLY_IN_LOOK1'
+  | 'ONLY_IN_LOOK2'
   | 'VALUES_CHANGED';
 
 export type EasingType =
@@ -412,11 +516,103 @@ export type EasingType =
   | 'LINEAR'
   | 'S_CURVE';
 
+/**
+ * Effect definition for DMX modulation.
+ * Effects can be waveform-based (LFO), crossfades, static values, or master faders.
+ */
+export type Effect = {
+  __typename?: 'Effect';
+  /** Amplitude as percentage (0-100) */
+  amplitude: Scalars['Float']['output'];
+  compositionMode: CompositionMode;
+  createdAt: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  effectType: EffectType;
+  fadeDuration?: Maybe<Scalars['Float']['output']>;
+  fixtures: Array<EffectFixture>;
+  /** Frequency in Hz */
+  frequency: Scalars['Float']['output'];
+  id: Scalars['ID']['output'];
+  /** Master value for MASTER effects (0.0-1.0) */
+  masterValue?: Maybe<Scalars['Float']['output']>;
+  name: Scalars['String']['output'];
+  /** Offset/baseline as percentage (0-100) */
+  offset: Scalars['Float']['output'];
+  onCueChange: TransitionBehavior;
+  /** Phase offset in degrees (0-360) */
+  phaseOffset: Scalars['Float']['output'];
+  priorityBand: PriorityBand;
+  prioritySub: Scalars['Int']['output'];
+  projectId: Scalars['ID']['output'];
+  updatedAt: Scalars['String']['output'];
+  /** Waveform type for WAVEFORM effects */
+  waveform?: Maybe<WaveformType>;
+};
+
+/** Per-channel overrides within an EffectFixture. */
+export type EffectChannel = {
+  __typename?: 'EffectChannel';
+  /** Per-channel amplitude multiplier */
+  amplitudeScale?: Maybe<Scalars['Float']['output']>;
+  /** Channel offset from fixture start address */
+  channelOffset?: Maybe<Scalars['Int']['output']>;
+  /** Channel type (INTENSITY, RED, etc.) */
+  channelType?: Maybe<Scalars['String']['output']>;
+  effectFixtureId: Scalars['ID']['output'];
+  /** Per-channel frequency multiplier */
+  frequencyScale?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+/**
+ * Input for adding or updating a channel within an effect fixture.
+ * Target by offset OR type (not both).
+ */
+export type EffectChannelInput = {
+  /** Amplitude scale for this channel (0-200%). Null uses effect's amplitude. */
+  amplitudeScale?: InputMaybe<Scalars['Float']['input']>;
+  /** Target by DMX offset (0-based). Null if targeting by type. */
+  channelOffset?: InputMaybe<Scalars['Int']['input']>;
+  /** Target by channel type. Null if targeting by offset. */
+  channelType?: InputMaybe<ChannelType>;
+  /** Frequency scale for this channel. Null uses effect's frequency. */
+  frequencyScale?: InputMaybe<Scalars['Float']['input']>;
+};
+
+/** Links an effect to a fixture with per-fixture settings. */
+export type EffectFixture = {
+  __typename?: 'EffectFixture';
+  /** Per-fixture amplitude multiplier */
+  amplitudeScale?: Maybe<Scalars['Float']['output']>;
+  channels: Array<EffectChannel>;
+  effectId: Scalars['ID']['output'];
+  /** Order of this fixture in the effect */
+  effectOrder?: Maybe<Scalars['Int']['output']>;
+  fixture?: Maybe<FixtureInstance>;
+  fixtureId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  /** Per-fixture phase offset in degrees */
+  phaseOffset?: Maybe<Scalars['Float']['output']>;
+};
+
+/**
+ * Type of effect, determining its calculation behavior.
+ * WAVEFORM - LFO-based continuous modulation using waveforms
+ * CROSSFADE - Interpolates between channel states over time
+ * STATIC - Sets channels to fixed values without modulation
+ * MASTER - Multiplier effect for intensity scaling (grand master)
+ */
+export type EffectType =
+  | 'CROSSFADE'
+  | 'MASTER'
+  | 'STATIC'
+  | 'WAVEFORM';
+
 export type ExportOptionsInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   includeCueLists?: InputMaybe<Scalars['Boolean']['input']>;
   includeFixtures?: InputMaybe<Scalars['Boolean']['input']>;
-  includeScenes?: InputMaybe<Scalars['Boolean']['input']>;
+  includeLooks?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ExportResult = {
@@ -433,12 +629,12 @@ export type ExportStats = {
   cuesCount: Scalars['Int']['output'];
   fixtureDefinitionsCount: Scalars['Int']['output'];
   fixtureInstancesCount: Scalars['Int']['output'];
-  sceneBoardsCount: Scalars['Int']['output'];
-  scenesCount: Scalars['Int']['output'];
+  lookBoardsCount: Scalars['Int']['output'];
+  looksCount: Scalars['Int']['output'];
 };
 
 /**
- * Determines how a channel behaves during scene transitions.
+ * Determines how a channel behaves during look transitions.
  * FADE - Interpolate smoothly between values (default for intensity, colors)
  * SNAP - Jump to target value at start of transition (for gobos, macros, effects)
  * SNAP_END - Jump to target value at end of transition
@@ -603,7 +799,7 @@ export type FixtureUsage = {
   cues: Array<CueUsageSummary>;
   fixtureId: Scalars['ID']['output'];
   fixtureName: Scalars['String']['output'];
-  scenes: Array<SceneSummary>;
+  looks: Array<LookSummary>;
 };
 
 export type FixtureValue = {
@@ -611,13 +807,13 @@ export type FixtureValue = {
   channels: Array<ChannelValue>;
   fixture: FixtureInstance;
   id: Scalars['ID']['output'];
-  sceneOrder?: Maybe<Scalars['Int']['output']>;
+  lookOrder?: Maybe<Scalars['Int']['output']>;
 };
 
 export type FixtureValueInput = {
   channels: Array<ChannelValueInput>;
   fixtureId: Scalars['ID']['input'];
-  sceneOrder?: InputMaybe<Scalars['Int']['input']>;
+  lookOrder?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Global playback status - returns which cue list is currently playing or paused (if any) */
@@ -637,7 +833,7 @@ export type GlobalPlaybackStatus = {
   fadeProgress?: Maybe<Scalars['Float']['output']>;
   /** True if a fade transition is in progress */
   isFading: Scalars['Boolean']['output'];
-  /** True if a cue list is paused (scene activated outside cue context) */
+  /** True if a cue list is paused (look activated outside cue context) */
   isPaused: Scalars['Boolean']['output'];
   /** True if any cue list is currently playing */
   isPlaying: Scalars['Boolean']['output'];
@@ -675,8 +871,8 @@ export type ImportStats = {
   cuesCreated: Scalars['Int']['output'];
   fixtureDefinitionsCreated: Scalars['Int']['output'];
   fixtureInstancesCreated: Scalars['Int']['output'];
-  sceneBoardsCreated: Scalars['Int']['output'];
-  scenesCreated: Scalars['Int']['output'];
+  lookBoardsCreated: Scalars['Int']['output'];
+  looksCreated: Scalars['Int']['output'];
 };
 
 export type InstanceChannel = {
@@ -698,6 +894,151 @@ export type LacyLightsFixture = {
   model: Scalars['String']['output'];
 };
 
+export type Look = {
+  __typename?: 'Look';
+  createdAt: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  fixtureValues: Array<FixtureValue>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  project: Project;
+  updatedAt: Scalars['String']['output'];
+};
+
+export type LookBoard = {
+  __typename?: 'LookBoard';
+  buttons: Array<LookBoardButton>;
+  canvasHeight: Scalars['Int']['output'];
+  canvasWidth: Scalars['Int']['output'];
+  createdAt: Scalars['String']['output'];
+  defaultFadeTime: Scalars['Float']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  gridSize?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  project: Project;
+  updatedAt: Scalars['String']['output'];
+};
+
+export type LookBoardButton = {
+  __typename?: 'LookBoardButton';
+  color?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['String']['output'];
+  height?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  label?: Maybe<Scalars['String']['output']>;
+  layoutX: Scalars['Int']['output'];
+  layoutY: Scalars['Int']['output'];
+  look: Look;
+  lookBoard: LookBoard;
+  updatedAt: Scalars['String']['output'];
+  width?: Maybe<Scalars['Int']['output']>;
+};
+
+export type LookBoardButtonPositionInput = {
+  buttonId: Scalars['ID']['input'];
+  layoutX: Scalars['Int']['input'];
+  layoutY: Scalars['Int']['input'];
+};
+
+export type LookBoardButtonUpdateItem = {
+  buttonId: Scalars['ID']['input'];
+  color?: InputMaybe<Scalars['String']['input']>;
+  height?: InputMaybe<Scalars['Int']['input']>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  layoutX?: InputMaybe<Scalars['Int']['input']>;
+  layoutY?: InputMaybe<Scalars['Int']['input']>;
+  width?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type LookBoardUpdateItem = {
+  canvasHeight?: InputMaybe<Scalars['Int']['input']>;
+  canvasWidth?: InputMaybe<Scalars['Int']['input']>;
+  defaultFadeTime?: InputMaybe<Scalars['Float']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  gridSize?: InputMaybe<Scalars['Int']['input']>;
+  lookBoardId: Scalars['ID']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type LookComparison = {
+  __typename?: 'LookComparison';
+  differences: Array<LookDifference>;
+  differentFixtureCount: Scalars['Int']['output'];
+  identicalFixtureCount: Scalars['Int']['output'];
+  look1: LookSummary;
+  look2: LookSummary;
+};
+
+export type LookDifference = {
+  __typename?: 'LookDifference';
+  differenceType: DifferenceType;
+  fixtureId: Scalars['ID']['output'];
+  fixtureName: Scalars['String']['output'];
+  look1Values?: Maybe<Array<Scalars['Int']['output']>>;
+  look2Values?: Maybe<Array<Scalars['Int']['output']>>;
+};
+
+export type LookFilterInput = {
+  nameContains?: InputMaybe<Scalars['String']['input']>;
+  usesFixture?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type LookFixtureSummary = {
+  __typename?: 'LookFixtureSummary';
+  fixtureId: Scalars['ID']['output'];
+  fixtureName: Scalars['String']['output'];
+  fixtureType: FixtureType;
+};
+
+export type LookPage = {
+  __typename?: 'LookPage';
+  looks: Array<LookSummary>;
+  pagination: PaginationInfo;
+};
+
+/**
+ * Partial update for a single look in a bulk operation.
+ * When mergeFixtures is true (default), only specified fixtures are updated.
+ * When false, all existing fixtures are replaced with the provided list.
+ */
+export type LookPartialUpdateItem = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  fixtureValues?: InputMaybe<Array<FixtureValueInput>>;
+  lookId: Scalars['ID']['input'];
+  /** When true (default), only specified fixtures are updated. When false, replaces all fixtures. */
+  mergeFixtures?: InputMaybe<Scalars['Boolean']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type LookSortField =
+  | 'CREATED_AT'
+  | 'NAME'
+  | 'UPDATED_AT';
+
+export type LookSummary = {
+  __typename?: 'LookSummary';
+  createdAt: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  fixtureCount: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['String']['output'];
+};
+
+export type LookUpdateItem = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  lookId: Scalars['ID']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type LookUsage = {
+  __typename?: 'LookUsage';
+  cues: Array<CueUsageSummary>;
+  lookId: Scalars['ID']['output'];
+  lookName: Scalars['String']['output'];
+};
+
 export type ModeChannel = {
   __typename?: 'ModeChannel';
   channel: ChannelDefinition;
@@ -705,59 +1046,89 @@ export type ModeChannel = {
   offset: Scalars['Int']['output'];
 };
 
+/** Status of the modulator engine. */
+export type ModulatorStatus = {
+  __typename?: 'ModulatorStatus';
+  activeEffectCount: Scalars['Int']['output'];
+  activeEffects: Array<ActiveEffectStatus>;
+  blackoutIntensity: Scalars['Float']['output'];
+  grandMasterValue: Scalars['Float']['output'];
+  /** Whether there's an active crossfade transition */
+  hasActiveTransition: Scalars['Boolean']['output'];
+  isBlackoutActive: Scalars['Boolean']['output'];
+  isRunning: Scalars['Boolean']['output'];
+  /** Progress of the active transition (0-100) */
+  transitionProgress: Scalars['Float']['output'];
+  updateRateHz: Scalars['Int']['output'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
-  activateSceneFromBoard: Scalars['Boolean']['output'];
-  addFixturesToScene: Scene;
-  addSceneToBoard: SceneBoardButton;
+  /** Activate the system blackout with optional fade time */
+  activateBlackout: Scalars['Boolean']['output'];
+  /** Activate an effect with optional fade time */
+  activateEffect: Scalars['Boolean']['output'];
+  activateLookFromBoard: Scalars['Boolean']['output'];
+  /** Add a channel to an effect fixture */
+  addChannelToEffectFixture: EffectChannel;
+  /** Add an effect to a cue with runtime parameters */
+  addEffectToCue: CueEffect;
+  /** Add a fixture to an effect with optional per-fixture settings */
+  addFixtureToEffect: EffectFixture;
+  addFixturesToLook: Look;
+  addLookToBoard: LookBoardButton;
   bulkCreateCueLists: Array<CueList>;
   bulkCreateCues: Array<Cue>;
   bulkCreateFixtureDefinitions: Array<FixtureDefinition>;
   bulkCreateFixtures: Array<FixtureInstance>;
+  bulkCreateLookBoardButtons: Array<LookBoardButton>;
+  bulkCreateLookBoards: Array<LookBoard>;
+  bulkCreateLooks: Array<Look>;
   bulkCreateProjects: Array<Project>;
-  bulkCreateSceneBoardButtons: Array<SceneBoardButton>;
-  bulkCreateSceneBoards: Array<SceneBoard>;
-  bulkCreateScenes: Array<Scene>;
   bulkDeleteCueLists: BulkDeleteResult;
   bulkDeleteCues: BulkDeleteResult;
   bulkDeleteFixtureDefinitions: BulkDeleteResult;
   bulkDeleteFixtures: BulkDeleteResult;
+  bulkDeleteLookBoardButtons: BulkDeleteResult;
+  bulkDeleteLookBoards: BulkDeleteResult;
+  bulkDeleteLooks: BulkDeleteResult;
   bulkDeleteProjects: BulkDeleteResult;
-  bulkDeleteSceneBoardButtons: BulkDeleteResult;
-  bulkDeleteSceneBoards: BulkDeleteResult;
-  bulkDeleteScenes: BulkDeleteResult;
   bulkUpdateCueLists: Array<CueList>;
   bulkUpdateCues: Array<Cue>;
   bulkUpdateFixtureDefinitions: Array<FixtureDefinition>;
   bulkUpdateFixtures: Array<FixtureInstance>;
   bulkUpdateInstanceChannelsFadeBehavior: Array<InstanceChannel>;
+  bulkUpdateLookBoardButtons: Array<LookBoardButton>;
+  bulkUpdateLookBoards: Array<LookBoard>;
+  bulkUpdateLooks: Array<Look>;
+  bulkUpdateLooksPartial: Array<Look>;
   bulkUpdateProjects: Array<Project>;
-  bulkUpdateSceneBoardButtons: Array<SceneBoardButton>;
-  bulkUpdateSceneBoards: Array<SceneBoard>;
-  bulkUpdateScenes: Array<Scene>;
-  bulkUpdateScenesPartial: Array<Scene>;
   /** Cancel an ongoing OFL import */
   cancelOFLImport: Scalars['Boolean']['output'];
   cancelPreviewSession: Scalars['Boolean']['output'];
-  cloneScene: Scene;
+  cloneLook: Look;
   commitPreviewSession: Scalars['Boolean']['output'];
   connectWiFi: WiFiConnectionResult;
   createCue: Cue;
   createCueList: CueList;
+  /** Create a new effect */
+  createEffect: Effect;
   createFixtureDefinition: FixtureDefinition;
   createFixtureInstance: FixtureInstance;
+  createLook: Look;
+  createLookBoard: LookBoard;
   createProject: Project;
-  createScene: Scene;
-  createSceneBoard: SceneBoard;
   deleteCue: Scalars['Boolean']['output'];
   deleteCueList: Scalars['Boolean']['output'];
+  /** Delete an effect */
+  deleteEffect: Scalars['Boolean']['output'];
   deleteFixtureDefinition: Scalars['Boolean']['output'];
   deleteFixtureInstance: Scalars['Boolean']['output'];
+  deleteLook: Scalars['Boolean']['output'];
+  deleteLookBoard: Scalars['Boolean']['output'];
   deleteProject: Scalars['Boolean']['output'];
-  deleteScene: Scalars['Boolean']['output'];
-  deleteSceneBoard: Scalars['Boolean']['output'];
   disconnectWiFi: WiFiConnectionResult;
-  duplicateScene: Scene;
+  duplicateLook: Look;
   exportProject: ExportResult;
   exportProjectToQLC: QlcExportResult;
   fadeToBlack: Scalars['Boolean']['output'];
@@ -766,65 +1137,112 @@ export type Mutation = {
   importOFLFixture: FixtureDefinition;
   importProject: ImportResult;
   importProjectFromQLC: QlcImportResult;
-  initializePreviewWithScene: Scalars['Boolean']['output'];
+  initializePreviewWithLook: Scalars['Boolean']['output'];
   nextCue: Scalars['Boolean']['output'];
   playCue: Scalars['Boolean']['output'];
   previousCue: Scalars['Boolean']['output'];
-  removeFixturesFromScene: Scene;
-  removeSceneFromBoard: Scalars['Boolean']['output'];
+  /** Release the system blackout with optional fade time */
+  releaseBlackout: Scalars['Boolean']['output'];
+  /** Remove a channel from an effect fixture */
+  removeChannelFromEffectFixture: Scalars['Boolean']['output'];
+  /** Remove an effect from a cue */
+  removeEffectFromCue: Scalars['Boolean']['output'];
+  /** Remove a fixture from an effect */
+  removeFixtureFromEffect: Scalars['Boolean']['output'];
+  removeFixturesFromLook: Look;
+  removeLookFromBoard: Scalars['Boolean']['output'];
   reorderCues: Scalars['Boolean']['output'];
+  reorderLookFixtures: Scalars['Boolean']['output'];
   reorderProjectFixtures: Scalars['Boolean']['output'];
-  reorderSceneFixtures: Scalars['Boolean']['output'];
   resetAPTimeout: Scalars['Boolean']['output'];
-  /** Resume a paused cue list by snapping to the current cue's scene values instantly */
+  /** Resume a paused cue list by snapping to the current cue's look values instantly */
   resumeCueList: Scalars['Boolean']['output'];
   setArtNetEnabled: ArtNetStatus;
   setChannelValue: Scalars['Boolean']['output'];
-  setSceneLive: Scalars['Boolean']['output'];
+  /** Set the grand master level (0.0-1.0) */
+  setGrandMaster: Scalars['Boolean']['output'];
+  setLookLive: Scalars['Boolean']['output'];
   setWiFiEnabled: WiFiStatus;
   startAPMode: WiFiModeResult;
   startCueList: Scalars['Boolean']['output'];
   startPreviewSession: PreviewSession;
   stopAPMode: WiFiModeResult;
   stopCueList: Scalars['Boolean']['output'];
+  /** Stop an active effect with optional fade time */
+  stopEffect: Scalars['Boolean']['output'];
+  /** Toggle the skip status of a cue (skip=true means the cue is bypassed during playback) */
+  toggleCueSkip: Cue;
   /** Trigger an OFL import/update operation */
   triggerOFLImport: OflImportResult;
   updateAllRepositories: Array<UpdateResult>;
   updateCue: Cue;
   updateCueList: CueList;
+  /** Update an existing effect */
+  updateEffect: Effect;
+  /** Update an effect channel */
+  updateEffectChannel: EffectChannel;
+  /** Update fixture-specific settings in an effect */
+  updateEffectFixture: EffectFixture;
   updateFadeUpdateRate: Scalars['Boolean']['output'];
   updateFixtureDefinition: FixtureDefinition;
   updateFixtureInstance: FixtureInstance;
   updateFixturePositions: Scalars['Boolean']['output'];
   updateInstanceChannelFadeBehavior: InstanceChannel;
+  updateLook: Look;
+  updateLookBoard: LookBoard;
+  updateLookBoardButton: LookBoardButton;
+  updateLookBoardButtonPositions: Scalars['Boolean']['output'];
+  updateLookPartial: Look;
   updatePreviewChannel: Scalars['Boolean']['output'];
   updateProject: Project;
   updateRepository: UpdateResult;
-  updateScene: Scene;
-  updateSceneBoard: SceneBoard;
-  updateSceneBoardButton: SceneBoardButton;
-  updateSceneBoardButtonPositions: Scalars['Boolean']['output'];
-  updateScenePartial: Scene;
   updateSetting: Setting;
 };
 
 
-export type MutationActivateSceneFromBoardArgs = {
+export type MutationActivateBlackoutArgs = {
+  fadeTime?: InputMaybe<Scalars['Float']['input']>;
+};
+
+
+export type MutationActivateEffectArgs = {
+  effectId: Scalars['ID']['input'];
+  fadeTime?: InputMaybe<Scalars['Float']['input']>;
+};
+
+
+export type MutationActivateLookFromBoardArgs = {
   fadeTimeOverride?: InputMaybe<Scalars['Float']['input']>;
-  sceneBoardId: Scalars['ID']['input'];
-  sceneId: Scalars['ID']['input'];
+  lookBoardId: Scalars['ID']['input'];
+  lookId: Scalars['ID']['input'];
 };
 
 
-export type MutationAddFixturesToSceneArgs = {
+export type MutationAddChannelToEffectFixtureArgs = {
+  effectFixtureId: Scalars['ID']['input'];
+  input: EffectChannelInput;
+};
+
+
+export type MutationAddEffectToCueArgs = {
+  input: AddEffectToCueInput;
+};
+
+
+export type MutationAddFixtureToEffectArgs = {
+  input: AddFixtureToEffectInput;
+};
+
+
+export type MutationAddFixturesToLookArgs = {
   fixtureValues: Array<FixtureValueInput>;
+  lookId: Scalars['ID']['input'];
   overwriteExisting?: InputMaybe<Scalars['Boolean']['input']>;
-  sceneId: Scalars['ID']['input'];
 };
 
 
-export type MutationAddSceneToBoardArgs = {
-  input: CreateSceneBoardButtonInput;
+export type MutationAddLookToBoardArgs = {
+  input: CreateLookBoardButtonInput;
 };
 
 
@@ -848,23 +1266,23 @@ export type MutationBulkCreateFixturesArgs = {
 };
 
 
+export type MutationBulkCreateLookBoardButtonsArgs = {
+  input: BulkLookBoardButtonCreateInput;
+};
+
+
+export type MutationBulkCreateLookBoardsArgs = {
+  input: BulkLookBoardCreateInput;
+};
+
+
+export type MutationBulkCreateLooksArgs = {
+  input: BulkLookCreateInput;
+};
+
+
 export type MutationBulkCreateProjectsArgs = {
   input: BulkProjectCreateInput;
-};
-
-
-export type MutationBulkCreateSceneBoardButtonsArgs = {
-  input: BulkSceneBoardButtonCreateInput;
-};
-
-
-export type MutationBulkCreateSceneBoardsArgs = {
-  input: BulkSceneBoardCreateInput;
-};
-
-
-export type MutationBulkCreateScenesArgs = {
-  input: BulkSceneCreateInput;
 };
 
 
@@ -888,23 +1306,23 @@ export type MutationBulkDeleteFixturesArgs = {
 };
 
 
-export type MutationBulkDeleteProjectsArgs = {
-  projectIds: Array<Scalars['ID']['input']>;
-};
-
-
-export type MutationBulkDeleteSceneBoardButtonsArgs = {
+export type MutationBulkDeleteLookBoardButtonsArgs = {
   buttonIds: Array<Scalars['ID']['input']>;
 };
 
 
-export type MutationBulkDeleteSceneBoardsArgs = {
-  sceneBoardIds: Array<Scalars['ID']['input']>;
+export type MutationBulkDeleteLookBoardsArgs = {
+  lookBoardIds: Array<Scalars['ID']['input']>;
 };
 
 
-export type MutationBulkDeleteScenesArgs = {
-  sceneIds: Array<Scalars['ID']['input']>;
+export type MutationBulkDeleteLooksArgs = {
+  lookIds: Array<Scalars['ID']['input']>;
+};
+
+
+export type MutationBulkDeleteProjectsArgs = {
+  projectIds: Array<Scalars['ID']['input']>;
 };
 
 
@@ -933,28 +1351,28 @@ export type MutationBulkUpdateInstanceChannelsFadeBehaviorArgs = {
 };
 
 
+export type MutationBulkUpdateLookBoardButtonsArgs = {
+  input: BulkLookBoardButtonUpdateInput;
+};
+
+
+export type MutationBulkUpdateLookBoardsArgs = {
+  input: BulkLookBoardUpdateInput;
+};
+
+
+export type MutationBulkUpdateLooksArgs = {
+  input: BulkLookUpdateInput;
+};
+
+
+export type MutationBulkUpdateLooksPartialArgs = {
+  input: BulkLookPartialUpdateInput;
+};
+
+
 export type MutationBulkUpdateProjectsArgs = {
   input: BulkProjectUpdateInput;
-};
-
-
-export type MutationBulkUpdateSceneBoardButtonsArgs = {
-  input: BulkSceneBoardButtonUpdateInput;
-};
-
-
-export type MutationBulkUpdateSceneBoardsArgs = {
-  input: BulkSceneBoardUpdateInput;
-};
-
-
-export type MutationBulkUpdateScenesArgs = {
-  input: BulkSceneUpdateInput;
-};
-
-
-export type MutationBulkUpdateScenesPartialArgs = {
-  input: BulkScenePartialUpdateInput;
 };
 
 
@@ -963,9 +1381,9 @@ export type MutationCancelPreviewSessionArgs = {
 };
 
 
-export type MutationCloneSceneArgs = {
+export type MutationCloneLookArgs = {
+  lookId: Scalars['ID']['input'];
   newName: Scalars['String']['input'];
-  sceneId: Scalars['ID']['input'];
 };
 
 
@@ -990,6 +1408,11 @@ export type MutationCreateCueListArgs = {
 };
 
 
+export type MutationCreateEffectArgs = {
+  input: CreateEffectInput;
+};
+
+
 export type MutationCreateFixtureDefinitionArgs = {
   input: CreateFixtureDefinitionInput;
 };
@@ -1000,18 +1423,18 @@ export type MutationCreateFixtureInstanceArgs = {
 };
 
 
+export type MutationCreateLookArgs = {
+  input: CreateLookInput;
+};
+
+
+export type MutationCreateLookBoardArgs = {
+  input: CreateLookBoardInput;
+};
+
+
 export type MutationCreateProjectArgs = {
   input: CreateProjectInput;
-};
-
-
-export type MutationCreateSceneArgs = {
-  input: CreateSceneInput;
-};
-
-
-export type MutationCreateSceneBoardArgs = {
-  input: CreateSceneBoardInput;
 };
 
 
@@ -1021,6 +1444,11 @@ export type MutationDeleteCueArgs = {
 
 
 export type MutationDeleteCueListArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteEffectArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -1035,22 +1463,22 @@ export type MutationDeleteFixtureInstanceArgs = {
 };
 
 
+export type MutationDeleteLookArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteLookBoardArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type MutationDeleteProjectArgs = {
   id: Scalars['ID']['input'];
 };
 
 
-export type MutationDeleteSceneArgs = {
-  id: Scalars['ID']['input'];
-};
-
-
-export type MutationDeleteSceneBoardArgs = {
-  id: Scalars['ID']['input'];
-};
-
-
-export type MutationDuplicateSceneArgs = {
+export type MutationDuplicateLookArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -1101,8 +1529,8 @@ export type MutationImportProjectFromQlcArgs = {
 };
 
 
-export type MutationInitializePreviewWithSceneArgs = {
-  sceneId: Scalars['ID']['input'];
+export type MutationInitializePreviewWithLookArgs = {
+  lookId: Scalars['ID']['input'];
   sessionId: Scalars['ID']['input'];
 };
 
@@ -1125,13 +1553,35 @@ export type MutationPreviousCueArgs = {
 };
 
 
-export type MutationRemoveFixturesFromSceneArgs = {
-  fixtureIds: Array<Scalars['ID']['input']>;
-  sceneId: Scalars['ID']['input'];
+export type MutationReleaseBlackoutArgs = {
+  fadeTime?: InputMaybe<Scalars['Float']['input']>;
 };
 
 
-export type MutationRemoveSceneFromBoardArgs = {
+export type MutationRemoveChannelFromEffectFixtureArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationRemoveEffectFromCueArgs = {
+  cueId: Scalars['ID']['input'];
+  effectId: Scalars['ID']['input'];
+};
+
+
+export type MutationRemoveFixtureFromEffectArgs = {
+  effectId: Scalars['ID']['input'];
+  fixtureId: Scalars['ID']['input'];
+};
+
+
+export type MutationRemoveFixturesFromLookArgs = {
+  fixtureIds: Array<Scalars['ID']['input']>;
+  lookId: Scalars['ID']['input'];
+};
+
+
+export type MutationRemoveLookFromBoardArgs = {
   buttonId: Scalars['ID']['input'];
 };
 
@@ -1142,15 +1592,15 @@ export type MutationReorderCuesArgs = {
 };
 
 
-export type MutationReorderProjectFixturesArgs = {
+export type MutationReorderLookFixturesArgs = {
   fixtureOrders: Array<FixtureOrderInput>;
-  projectId: Scalars['ID']['input'];
+  lookId: Scalars['ID']['input'];
 };
 
 
-export type MutationReorderSceneFixturesArgs = {
+export type MutationReorderProjectFixturesArgs = {
   fixtureOrders: Array<FixtureOrderInput>;
-  sceneId: Scalars['ID']['input'];
+  projectId: Scalars['ID']['input'];
 };
 
 
@@ -1172,8 +1622,13 @@ export type MutationSetChannelValueArgs = {
 };
 
 
-export type MutationSetSceneLiveArgs = {
-  sceneId: Scalars['ID']['input'];
+export type MutationSetGrandMasterArgs = {
+  value: Scalars['Float']['input'];
+};
+
+
+export type MutationSetLookLiveArgs = {
+  lookId: Scalars['ID']['input'];
 };
 
 
@@ -1204,6 +1659,17 @@ export type MutationStopCueListArgs = {
 };
 
 
+export type MutationStopEffectArgs = {
+  effectId: Scalars['ID']['input'];
+  fadeTime?: InputMaybe<Scalars['Float']['input']>;
+};
+
+
+export type MutationToggleCueSkipArgs = {
+  cueId: Scalars['ID']['input'];
+};
+
+
 export type MutationTriggerOflImportArgs = {
   options?: InputMaybe<OflImportOptionsInput>;
 };
@@ -1218,6 +1684,24 @@ export type MutationUpdateCueArgs = {
 export type MutationUpdateCueListArgs = {
   id: Scalars['ID']['input'];
   input: CreateCueListInput;
+};
+
+
+export type MutationUpdateEffectArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateEffectInput;
+};
+
+
+export type MutationUpdateEffectChannelArgs = {
+  id: Scalars['ID']['input'];
+  input: EffectChannelInput;
+};
+
+
+export type MutationUpdateEffectFixtureArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateEffectFixtureInput;
 };
 
 
@@ -1249,6 +1733,38 @@ export type MutationUpdateInstanceChannelFadeBehaviorArgs = {
 };
 
 
+export type MutationUpdateLookArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateLookInput;
+};
+
+
+export type MutationUpdateLookBoardArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateLookBoardInput;
+};
+
+
+export type MutationUpdateLookBoardButtonArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateLookBoardButtonInput;
+};
+
+
+export type MutationUpdateLookBoardButtonPositionsArgs = {
+  positions: Array<LookBoardButtonPositionInput>;
+};
+
+
+export type MutationUpdateLookPartialArgs = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  fixtureValues?: InputMaybe<Array<FixtureValueInput>>;
+  lookId: Scalars['ID']['input'];
+  mergeFixtures?: InputMaybe<Scalars['Boolean']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type MutationUpdatePreviewChannelArgs = {
   channelIndex: Scalars['Int']['input'];
   fixtureId: Scalars['ID']['input'];
@@ -1266,38 +1782,6 @@ export type MutationUpdateProjectArgs = {
 export type MutationUpdateRepositoryArgs = {
   repository: Scalars['String']['input'];
   version?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type MutationUpdateSceneArgs = {
-  id: Scalars['ID']['input'];
-  input: UpdateSceneInput;
-};
-
-
-export type MutationUpdateSceneBoardArgs = {
-  id: Scalars['ID']['input'];
-  input: UpdateSceneBoardInput;
-};
-
-
-export type MutationUpdateSceneBoardButtonArgs = {
-  id: Scalars['ID']['input'];
-  input: UpdateSceneBoardButtonInput;
-};
-
-
-export type MutationUpdateSceneBoardButtonPositionsArgs = {
-  positions: Array<SceneBoardButtonPositionInput>;
-};
-
-
-export type MutationUpdateScenePartialArgs = {
-  description?: InputMaybe<Scalars['String']['input']>;
-  fixtureValues?: InputMaybe<Array<FixtureValueInput>>;
-  mergeFixtures?: InputMaybe<Scalars['Boolean']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  sceneId: Scalars['ID']['input'];
 };
 
 
@@ -1459,6 +1943,16 @@ export type PreviewSession = {
   user: User;
 };
 
+/**
+ * Priority band determines effect processing order.
+ * Effects in higher bands (SYSTEM) override effects in lower bands (BASE).
+ */
+export type PriorityBand =
+  | 'BASE'
+  | 'CUE'
+  | 'SYSTEM'
+  | 'USER';
+
 export type Project = {
   __typename?: 'Project';
   createdAt: Scalars['String']['output'];
@@ -1470,10 +1964,10 @@ export type Project = {
   id: Scalars['ID']['output'];
   layoutCanvasHeight: Scalars['Int']['output'];
   layoutCanvasWidth: Scalars['Int']['output'];
+  lookBoards: Array<LookBoard>;
+  lookCount: Scalars['Int']['output'];
+  looks: Array<Look>;
   name: Scalars['String']['output'];
-  sceneBoards: Array<SceneBoard>;
-  sceneCount: Scalars['Int']['output'];
-  scenes: Array<Scene>;
   updatedAt: Scalars['String']['output'];
   users: Array<ProjectUser>;
 };
@@ -1504,8 +1998,8 @@ export type QlcExportResult = {
   __typename?: 'QLCExportResult';
   cueListCount: Scalars['Int']['output'];
   fixtureCount: Scalars['Int']['output'];
+  lookCount: Scalars['Int']['output'];
   projectName: Scalars['String']['output'];
-  sceneCount: Scalars['Int']['output'];
   xmlContent: Scalars['String']['output'];
 };
 
@@ -1535,9 +2029,9 @@ export type QlcImportResult = {
   __typename?: 'QLCImportResult';
   cueListCount: Scalars['Int']['output'];
   fixtureCount: Scalars['Int']['output'];
+  lookCount: Scalars['Int']['output'];
   originalFileName: Scalars['String']['output'];
   project: Project;
-  sceneCount: Scalars['Int']['output'];
   warnings: Array<Scalars['String']['output']>;
 };
 
@@ -1553,15 +2047,19 @@ export type Query = {
   channelMap: ChannelMapResult;
   /** Check for available OFL updates without importing */
   checkOFLUpdates: OflUpdateCheckResult;
-  compareScenes: SceneComparison;
+  compareLooks: LookComparison;
   cue?: Maybe<Cue>;
   cueList?: Maybe<CueList>;
   cueListPlaybackStatus?: Maybe<CueListPlaybackStatus>;
   cueLists: Array<CueListSummary>;
   cueListsByIds: Array<CueList>;
   cuesByIds: Array<Cue>;
-  currentActiveScene?: Maybe<Scene>;
+  currentActiveLook?: Maybe<Look>;
   dmxOutput: Array<Scalars['Int']['output']>;
+  /** Get a single effect by ID */
+  effect?: Maybe<Effect>;
+  /** List all effects in a project */
+  effects: Array<Effect>;
   fixtureDefinition?: Maybe<FixtureDefinition>;
   fixtureDefinitions: Array<FixtureDefinition>;
   fixtureDefinitionsByIds: Array<FixtureDefinition>;
@@ -1572,6 +2070,17 @@ export type Query = {
   getQLCFixtureMappingSuggestions: QlcFixtureMappingResult;
   /** Get global playback status - which cue list is currently playing (if any) */
   globalPlaybackStatus: GlobalPlaybackStatus;
+  look?: Maybe<Look>;
+  lookBoard?: Maybe<LookBoard>;
+  lookBoardButton?: Maybe<LookBoardButton>;
+  lookBoards: Array<LookBoard>;
+  lookBoardsByIds: Array<LookBoard>;
+  lookFixtures: Array<LookFixtureSummary>;
+  lookUsage: LookUsage;
+  looks: LookPage;
+  looksByIds: Array<Look>;
+  /** Get the current status of the modulator engine */
+  modulatorStatus: ModulatorStatus;
   networkInterfaceOptions: Array<NetworkInterfaceOption>;
   /** Get the current status of any ongoing OFL import */
   oflImportStatus: OflImportStatus;
@@ -1580,18 +2089,9 @@ export type Query = {
   projects: Array<Project>;
   projectsByIds: Array<Project>;
   savedWifiNetworks: Array<WiFiNetwork>;
-  scene?: Maybe<Scene>;
-  sceneBoard?: Maybe<SceneBoard>;
-  sceneBoardButton?: Maybe<SceneBoardButton>;
-  sceneBoards: Array<SceneBoard>;
-  sceneBoardsByIds: Array<SceneBoard>;
-  sceneFixtures: Array<SceneFixtureSummary>;
-  sceneUsage: SceneUsage;
-  scenes: ScenePage;
-  scenesByIds: Array<Scene>;
   searchCues: CuePage;
   searchFixtures: FixtureInstancePage;
-  searchScenes: ScenePage;
+  searchLooks: LookPage;
   setting?: Maybe<Setting>;
   settings: Array<Setting>;
   suggestChannelAssignment: ChannelAssignmentSuggestion;
@@ -1614,9 +2114,9 @@ export type QueryChannelMapArgs = {
 };
 
 
-export type QueryCompareScenesArgs = {
-  sceneId1: Scalars['ID']['input'];
-  sceneId2: Scalars['ID']['input'];
+export type QueryCompareLooksArgs = {
+  lookId1: Scalars['ID']['input'];
+  lookId2: Scalars['ID']['input'];
 };
 
 
@@ -1627,7 +2127,7 @@ export type QueryCueArgs = {
 
 export type QueryCueListArgs = {
   id: Scalars['ID']['input'];
-  includeSceneDetails?: InputMaybe<Scalars['Boolean']['input']>;
+  includeLookDetails?: InputMaybe<Scalars['Boolean']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
   perPage?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -1655,6 +2155,16 @@ export type QueryCuesByIdsArgs = {
 
 export type QueryDmxOutputArgs = {
   universe: Scalars['Int']['input'];
+};
+
+
+export type QueryEffectArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryEffectsArgs = {
+  projectId: Scalars['ID']['input'];
 };
 
 
@@ -1701,6 +2211,56 @@ export type QueryGetQlcFixtureMappingSuggestionsArgs = {
 };
 
 
+export type QueryLookArgs = {
+  id: Scalars['ID']['input'];
+  includeFixtureValues?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryLookBoardArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryLookBoardButtonArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryLookBoardsArgs = {
+  projectId: Scalars['ID']['input'];
+};
+
+
+export type QueryLookBoardsByIdsArgs = {
+  ids: Array<Scalars['ID']['input']>;
+};
+
+
+export type QueryLookFixturesArgs = {
+  lookId: Scalars['ID']['input'];
+};
+
+
+export type QueryLookUsageArgs = {
+  lookId: Scalars['ID']['input'];
+};
+
+
+export type QueryLooksArgs = {
+  filter?: InputMaybe<LookFilterInput>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  perPage?: InputMaybe<Scalars['Int']['input']>;
+  projectId: Scalars['ID']['input'];
+  sortBy?: InputMaybe<LookSortField>;
+};
+
+
+export type QueryLooksByIdsArgs = {
+  ids: Array<Scalars['ID']['input']>;
+};
+
+
 export type QueryPreviewSessionArgs = {
   sessionId: Scalars['ID']['input'];
 };
@@ -1712,56 +2272,6 @@ export type QueryProjectArgs = {
 
 
 export type QueryProjectsByIdsArgs = {
-  ids: Array<Scalars['ID']['input']>;
-};
-
-
-export type QuerySceneArgs = {
-  id: Scalars['ID']['input'];
-  includeFixtureValues?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-
-export type QuerySceneBoardArgs = {
-  id: Scalars['ID']['input'];
-};
-
-
-export type QuerySceneBoardButtonArgs = {
-  id: Scalars['ID']['input'];
-};
-
-
-export type QuerySceneBoardsArgs = {
-  projectId: Scalars['ID']['input'];
-};
-
-
-export type QuerySceneBoardsByIdsArgs = {
-  ids: Array<Scalars['ID']['input']>;
-};
-
-
-export type QuerySceneFixturesArgs = {
-  sceneId: Scalars['ID']['input'];
-};
-
-
-export type QuerySceneUsageArgs = {
-  sceneId: Scalars['ID']['input'];
-};
-
-
-export type QueryScenesArgs = {
-  filter?: InputMaybe<SceneFilterInput>;
-  page?: InputMaybe<Scalars['Int']['input']>;
-  perPage?: InputMaybe<Scalars['Int']['input']>;
-  projectId: Scalars['ID']['input'];
-  sortBy?: InputMaybe<SceneSortField>;
-};
-
-
-export type QueryScenesByIdsArgs = {
   ids: Array<Scalars['ID']['input']>;
 };
 
@@ -1783,8 +2293,8 @@ export type QuerySearchFixturesArgs = {
 };
 
 
-export type QuerySearchScenesArgs = {
-  filter?: InputMaybe<SceneFilterInput>;
+export type QuerySearchLooksArgs = {
+  filter?: InputMaybe<LookFilterInput>;
   page?: InputMaybe<Scalars['Int']['input']>;
   perPage?: InputMaybe<Scalars['Int']['input']>;
   projectId: Scalars['ID']['input'];
@@ -1815,151 +2325,6 @@ export type RepositoryVersion = {
   updateAvailable: Scalars['Boolean']['output'];
 };
 
-export type Scene = {
-  __typename?: 'Scene';
-  createdAt: Scalars['String']['output'];
-  description?: Maybe<Scalars['String']['output']>;
-  fixtureValues: Array<FixtureValue>;
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  project: Project;
-  updatedAt: Scalars['String']['output'];
-};
-
-export type SceneBoard = {
-  __typename?: 'SceneBoard';
-  buttons: Array<SceneBoardButton>;
-  canvasHeight: Scalars['Int']['output'];
-  canvasWidth: Scalars['Int']['output'];
-  createdAt: Scalars['String']['output'];
-  defaultFadeTime: Scalars['Float']['output'];
-  description?: Maybe<Scalars['String']['output']>;
-  gridSize?: Maybe<Scalars['Int']['output']>;
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  project: Project;
-  updatedAt: Scalars['String']['output'];
-};
-
-export type SceneBoardButton = {
-  __typename?: 'SceneBoardButton';
-  color?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['String']['output'];
-  height?: Maybe<Scalars['Int']['output']>;
-  id: Scalars['ID']['output'];
-  label?: Maybe<Scalars['String']['output']>;
-  layoutX: Scalars['Int']['output'];
-  layoutY: Scalars['Int']['output'];
-  scene: Scene;
-  sceneBoard: SceneBoard;
-  updatedAt: Scalars['String']['output'];
-  width?: Maybe<Scalars['Int']['output']>;
-};
-
-export type SceneBoardButtonPositionInput = {
-  buttonId: Scalars['ID']['input'];
-  layoutX: Scalars['Int']['input'];
-  layoutY: Scalars['Int']['input'];
-};
-
-export type SceneBoardButtonUpdateItem = {
-  buttonId: Scalars['ID']['input'];
-  color?: InputMaybe<Scalars['String']['input']>;
-  height?: InputMaybe<Scalars['Int']['input']>;
-  label?: InputMaybe<Scalars['String']['input']>;
-  layoutX?: InputMaybe<Scalars['Int']['input']>;
-  layoutY?: InputMaybe<Scalars['Int']['input']>;
-  width?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export type SceneBoardUpdateItem = {
-  canvasHeight?: InputMaybe<Scalars['Int']['input']>;
-  canvasWidth?: InputMaybe<Scalars['Int']['input']>;
-  defaultFadeTime?: InputMaybe<Scalars['Float']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  gridSize?: InputMaybe<Scalars['Int']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  sceneBoardId: Scalars['ID']['input'];
-};
-
-export type SceneComparison = {
-  __typename?: 'SceneComparison';
-  differences: Array<SceneDifference>;
-  differentFixtureCount: Scalars['Int']['output'];
-  identicalFixtureCount: Scalars['Int']['output'];
-  scene1: SceneSummary;
-  scene2: SceneSummary;
-};
-
-export type SceneDifference = {
-  __typename?: 'SceneDifference';
-  differenceType: DifferenceType;
-  fixtureId: Scalars['ID']['output'];
-  fixtureName: Scalars['String']['output'];
-  scene1Values?: Maybe<Array<Scalars['Int']['output']>>;
-  scene2Values?: Maybe<Array<Scalars['Int']['output']>>;
-};
-
-export type SceneFilterInput = {
-  nameContains?: InputMaybe<Scalars['String']['input']>;
-  usesFixture?: InputMaybe<Scalars['ID']['input']>;
-};
-
-export type SceneFixtureSummary = {
-  __typename?: 'SceneFixtureSummary';
-  fixtureId: Scalars['ID']['output'];
-  fixtureName: Scalars['String']['output'];
-  fixtureType: FixtureType;
-};
-
-export type ScenePage = {
-  __typename?: 'ScenePage';
-  pagination: PaginationInfo;
-  scenes: Array<SceneSummary>;
-};
-
-/**
- * Partial update for a single scene in a bulk operation.
- * When mergeFixtures is true (default), only specified fixtures are updated.
- * When false, all existing fixtures are replaced with the provided list.
- */
-export type ScenePartialUpdateItem = {
-  description?: InputMaybe<Scalars['String']['input']>;
-  fixtureValues?: InputMaybe<Array<FixtureValueInput>>;
-  /** When true (default), only specified fixtures are updated. When false, replaces all fixtures. */
-  mergeFixtures?: InputMaybe<Scalars['Boolean']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  sceneId: Scalars['ID']['input'];
-};
-
-export type SceneSortField =
-  | 'CREATED_AT'
-  | 'NAME'
-  | 'UPDATED_AT';
-
-export type SceneSummary = {
-  __typename?: 'SceneSummary';
-  createdAt: Scalars['String']['output'];
-  description?: Maybe<Scalars['String']['output']>;
-  fixtureCount: Scalars['Int']['output'];
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  updatedAt: Scalars['String']['output'];
-};
-
-export type SceneUpdateItem = {
-  description?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  sceneId: Scalars['ID']['input'];
-};
-
-export type SceneUsage = {
-  __typename?: 'SceneUsage';
-  cues: Array<CueUsageSummary>;
-  sceneId: Scalars['ID']['output'];
-  sceneName: Scalars['String']['output'];
-};
-
 export type Setting = {
   __typename?: 'Setting';
   createdAt: Scalars['String']['output'];
@@ -1971,6 +2336,8 @@ export type Setting = {
 
 export type Subscription = {
   __typename?: 'Subscription';
+  /** Real-time updates when cue list data changes (cue added/updated/removed, reordering, metadata changes, look name changes) */
+  cueListDataChanged: CueListDataChangedPayload;
   cueListPlaybackUpdated: CueListPlaybackStatus;
   dmxOutputChanged: UniverseOutput;
   /** Global playback status updates - triggered when any cue list starts/stops/changes cue */
@@ -1982,6 +2349,11 @@ export type Subscription = {
   systemInfoUpdated: SystemInfo;
   wifiModeChanged: WiFiMode;
   wifiStatusUpdated: WiFiStatus;
+};
+
+
+export type SubscriptionCueListDataChangedArgs = {
+  cueListId: Scalars['ID']['input'];
 };
 
 
@@ -2018,6 +2390,19 @@ export type SystemVersionInfo = {
   versionManagementSupported: Scalars['Boolean']['output'];
 };
 
+/**
+ * How an effect behaves when a cue change occurs.
+ * FADE_OUT - Effect fades out when cue changes
+ * PERSIST - Effect persists across cue changes
+ * SNAP_OFF - Effect immediately stops when cue changes
+ * CROSSFADE_PARAMS - Effect parameters crossfade to new values
+ */
+export type TransitionBehavior =
+  | 'CROSSFADE_PARAMS'
+  | 'FADE_OUT'
+  | 'PERSIST'
+  | 'SNAP_OFF';
+
 export type UniverseChannelMap = {
   __typename?: 'UniverseChannelMap';
   availableChannels: Scalars['Int']['output'];
@@ -2031,6 +2416,33 @@ export type UniverseOutput = {
   __typename?: 'UniverseOutput';
   channels: Array<Scalars['Int']['output']>;
   universe: Scalars['Int']['output'];
+};
+
+/** Input for updating an effect fixture's settings. */
+export type UpdateEffectFixtureInput = {
+  /** Amplitude scale for this fixture (0-200%). */
+  amplitudeScale?: InputMaybe<Scalars['Float']['input']>;
+  /** Order for auto-phase distribution. */
+  effectOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** Phase offset override for this fixture (degrees). */
+  phaseOffset?: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type UpdateEffectInput = {
+  amplitude?: InputMaybe<Scalars['Float']['input']>;
+  compositionMode?: InputMaybe<CompositionMode>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  effectType?: InputMaybe<EffectType>;
+  fadeDuration?: InputMaybe<Scalars['Float']['input']>;
+  frequency?: InputMaybe<Scalars['Float']['input']>;
+  masterValue?: InputMaybe<Scalars['Float']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  offset?: InputMaybe<Scalars['Float']['input']>;
+  onCueChange?: InputMaybe<TransitionBehavior>;
+  phaseOffset?: InputMaybe<Scalars['Float']['input']>;
+  priorityBand?: InputMaybe<PriorityBand>;
+  prioritySub?: InputMaybe<Scalars['Int']['input']>;
+  waveform?: InputMaybe<WaveformType>;
 };
 
 export type UpdateFixtureInstanceInput = {
@@ -2047,17 +2459,7 @@ export type UpdateFixtureInstanceInput = {
   universe?: InputMaybe<Scalars['Int']['input']>;
 };
 
-export type UpdateResult = {
-  __typename?: 'UpdateResult';
-  error?: Maybe<Scalars['String']['output']>;
-  message?: Maybe<Scalars['String']['output']>;
-  newVersion: Scalars['String']['output'];
-  previousVersion: Scalars['String']['output'];
-  repository: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
-export type UpdateSceneBoardButtonInput = {
+export type UpdateLookBoardButtonInput = {
   color?: InputMaybe<Scalars['String']['input']>;
   height?: InputMaybe<Scalars['Int']['input']>;
   label?: InputMaybe<Scalars['String']['input']>;
@@ -2066,7 +2468,7 @@ export type UpdateSceneBoardButtonInput = {
   width?: InputMaybe<Scalars['Int']['input']>;
 };
 
-export type UpdateSceneBoardInput = {
+export type UpdateLookBoardInput = {
   canvasHeight?: InputMaybe<Scalars['Int']['input']>;
   canvasWidth?: InputMaybe<Scalars['Int']['input']>;
   defaultFadeTime?: InputMaybe<Scalars['Float']['input']>;
@@ -2075,10 +2477,20 @@ export type UpdateSceneBoardInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdateSceneInput = {
+export type UpdateLookInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   fixtureValues?: InputMaybe<Array<FixtureValueInput>>;
   name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateResult = {
+  __typename?: 'UpdateResult';
+  error?: Maybe<Scalars['String']['output']>;
+  message?: Maybe<Scalars['String']['output']>;
+  newVersion: Scalars['String']['output'];
+  previousVersion: Scalars['String']['output'];
+  repository: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateSettingInput = {
@@ -2098,6 +2510,15 @@ export type User = {
 export type UserRole =
   | 'ADMIN'
   | 'USER';
+
+/** Waveform type for LFO-based effects. */
+export type WaveformType =
+  | 'COSINE'
+  | 'RANDOM'
+  | 'SAWTOOTH'
+  | 'SINE'
+  | 'SQUARE'
+  | 'TRIANGLE';
 
 export type WiFiConnectionResult = {
   __typename?: 'WiFiConnectionResult';


### PR DESCRIPTION
## Summary
- Regenerate TypeScript GraphQL types to match backend schema changes
- Add Effect types and enums (CompositionMode, WaveformType, etc.)
- Add CueEffect relationships for per-cue effect support
- Include new mutations (addEffectToCue, removeEffectFromCue)

## Test plan
- [ ] Verify TypeScript compilation succeeds
- [ ] Confirm generated types match backend schema
- [ ] Test MCP server starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)