### PR TITLE
Add Eos ASCII import/export MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,3 +212,14 @@ mockFetch.mockResolvedValue({
 - `get_operation_history` - Get paginated operation history for a project
 - `jump_to_operation` - Jump to a specific point in history
 - `clear_operation_history` - Clear all operation history (destructive)
+
+### Eos ASCII Import/Export Tools
+- `import_eos_ascii(asciiContent, newProjectName?, targetProjectId?)` -
+  Import an ETC Eos ASCII (.asc) showfile into a new or existing project.
+  `newProjectName` and `targetProjectId` are mutually exclusive.
+- `export_eos_ascii(projectId)` - Export a project as ETC Eos ASCII text.
+- Both wrap GraphQL mutations on lacylights-go and surface structured
+  warnings to the agent (e.g. `EFFECT_SKIPPED`, `UNPATCHED_CHANNEL`,
+  `FIXTURE_SYNTHESIZED`, `GROUP_AUTO_ASSIGNED`).
+- Implementation: `src/tools/eos-tools.ts` (Zod-validated args) +
+  `src/services/graphql-client-simple.ts` (typed GraphQL methods).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2546,9 +2546,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3273,9 +3273,9 @@
       }
     },
     "node_modules/@jest/console/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3489,9 +3489,9 @@
       }
     },
     "node_modules/@jest/core/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3611,9 +3611,9 @@
       }
     },
     "node_modules/@jest/environment/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3800,9 +3800,9 @@
       }
     },
     "node_modules/@jest/expect/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3932,9 +3932,9 @@
       }
     },
     "node_modules/@jest/fake-timers/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4038,9 +4038,9 @@
       }
     },
     "node_modules/@jest/globals/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4269,9 +4269,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4506,9 +4506,9 @@
       }
     },
     "node_modules/@jest/test-sequencer/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5836,9 +5836,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7120,12 +7120,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7326,9 +7326,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7566,9 +7566,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7577,9 +7577,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7757,9 +7757,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7824,9 +7824,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
-      "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7991,9 +7991,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8369,9 +8369,9 @@
       }
     },
     "node_modules/jest-changed-files/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8517,9 +8517,9 @@
       }
     },
     "node_modules/jest-circus/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8615,9 +8615,9 @@
       }
     },
     "node_modules/jest-cli/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8874,9 +8874,9 @@
       }
     },
     "node_modules/jest-config/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9014,9 +9014,9 @@
       }
     },
     "node_modules/jest-each/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9113,9 +9113,9 @@
       }
     },
     "node_modules/jest-environment-node/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9361,9 +9361,9 @@
       }
     },
     "node_modules/jest-resolve/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9564,9 +9564,9 @@
       }
     },
     "node_modules/jest-runner/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9818,9 +9818,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10113,9 +10113,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10175,9 +10175,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10323,9 +10323,9 @@
       }
     },
     "node_modules/jest-watcher/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10993,13 +10993,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11502,9 +11502,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -11529,9 +11529,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12500,9 +12500,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12511,9 +12511,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -12569,9 +12569,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13207,9 +13207,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13217,6 +13217,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { SettingsTools } from "./tools/settings-tools";
 import { LookBoardTools } from "./tools/look-board-tools";
 import { UndoRedoTools } from "./tools/undo-redo-tools";
 import { GroupTools } from "./tools/group-tools";
+import { EosTools } from "./tools/eos-tools";
 import { logger } from "./utils/logger";
 import { getDeviceFingerprint, getDeviceName } from "./utils/device-fingerprint";
 
@@ -45,6 +46,7 @@ class LacyLightsMCPServer {
   private lookBoardTools: LookBoardTools;
   private undoRedoTools: UndoRedoTools;
   private groupTools: GroupTools;
+  private eosTools: EosTools;
 
   constructor() {
     this.server = new Server(
@@ -92,6 +94,7 @@ class LacyLightsMCPServer {
     this.lookBoardTools = new LookBoardTools(this.graphqlClient);
     this.undoRedoTools = new UndoRedoTools(this.graphqlClient);
     this.groupTools = new GroupTools(this.graphqlClient);
+    this.eosTools = new EosTools(this.graphqlClient);
 
     this.setupHandlers();
   }
@@ -263,6 +266,56 @@ Use this tool first to understand project scope before drilling down into specif
             inputSchema: {
               type: "object",
               properties: {},
+            },
+          },
+          {
+            name: "import_eos_ascii",
+            description: `Import an ETC Eos ASCII (.asc) showfile into LacyLights.
+
+Creates a new project (or appends into an existing one if targetProjectId is given) populated with the patch, cues, palettes, and groups from the Eos showfile. EOS-only concepts (effects, partitions, magic sheets, action triggers, curves, submasters) are skipped and surfaced as structured warnings. Palettes/presets are imported as standalone Looks in dedicated cue lists ("Color Palettes", "Beam Palettes", etc.).
+
+Returns:
+- projectId: the created or updated project
+- counts of fixtures, looks, cue lists, cues, groups created
+- warnings: structured list with code/severity/message/context entries
+- synthesizedDefinitionIds: definitions auto-synthesized when no library match was found
+
+Provide either newProjectName or targetProjectId, not both. If both are omitted, the project name comes from the showfile's $$Title.`,
+            inputSchema: {
+              type: "object",
+              properties: {
+                asciiContent: {
+                  type: "string",
+                  description: "Full text content of the .asc showfile.",
+                },
+                newProjectName: {
+                  type: "string",
+                  description: "Optional explicit name for the new project.",
+                },
+                targetProjectId: {
+                  type: "string",
+                  description: "Optional existing project ID to append the import into. Existing data is preserved.",
+                },
+              },
+              required: ["asciiContent"],
+            },
+          },
+          {
+            name: "export_eos_ascii",
+            description: `Export a LacyLights project as an ETC Eos ASCII (.asc) showfile.
+
+Returns the file content as a string along with a suggested filename suffix and any export warnings. LacyLights-only concepts (Look Boards, per-channel fade behaviors, synthesized definitions) ride along as $$ LACYLIGHTS: comment lines at the end of file so a subsequent re-import preserves them. EOS itself ignores those comments.
+
+Output is deterministic: the same project produces byte-identical output across runs.`,
+            inputSchema: {
+              type: "object",
+              properties: {
+                projectId: {
+                  type: "string",
+                  description: "Project ID to export.",
+                },
+              },
+              required: ["projectId"],
             },
           },
           // Fixture Tools
@@ -3318,6 +3371,34 @@ Returns:
                     why_not_here: "QLC+ files are typically 10-100KB+ of XML content, which exceeds practical limits for AI chat context windows. The web UI is optimized for file handling.",
                     export_available: "QLC+ export is still available via this MCP interface and can generate .qxw files for download."
                   }, null, 2),
+                },
+              ],
+            };
+
+          case "import_eos_ascii":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.eosTools.importEosAscii(args as any),
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+
+          case "export_eos_ascii":
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    await this.eosTools.exportEosAscii(args as any),
+                    null,
+                    2,
+                  ),
                 },
               ],
             };

--- a/src/services/graphql-client-simple.ts
+++ b/src/services/graphql-client-simple.ts
@@ -3413,7 +3413,7 @@ export class LacyLightsGraphQLClient {
 
     const data = await this.query(mutation, {
       asciiContent,
-      options: options ?? null,
+      options,
     });
     return data.importProjectFromEos;
   }

--- a/src/services/graphql-client-simple.ts
+++ b/src/services/graphql-client-simple.ts
@@ -3375,4 +3375,100 @@ export class LacyLightsGraphQLClient {
     const data = await this.query(mutation, { groupId, email, role: role || 'MEMBER' });
     return data.inviteToGroup;
   }
+
+  // ============================================================
+  // ETC Eos ASCII Import/Export
+  // ============================================================
+
+  async importEosAscii(
+    asciiContent: string,
+    options?: { newProjectName?: string; targetProjectId?: string },
+  ): Promise<EosImportResult> {
+    const mutation = `
+      mutation ImportProjectFromEos(
+        $asciiContent: String!
+        $options: EosImportOptionsInput
+      ) {
+        importProjectFromEos(
+          asciiContent: $asciiContent
+          options: $options
+        ) {
+          projectId
+          fixtureDefinitionsCount
+          fixtureInstancesCount
+          looksCount
+          cueListsCount
+          cuesCount
+          groupsCount
+          warnings {
+            code
+            severity
+            message
+            context { key value }
+          }
+          synthesizedDefinitionIds
+        }
+      }
+    `;
+
+    const data = await this.query(mutation, {
+      asciiContent,
+      options: options ?? null,
+    });
+    return data.importProjectFromEos;
+  }
+
+  async exportEosAscii(projectId: string): Promise<EosExportResult> {
+    const mutation = `
+      mutation ExportProjectToEos($projectId: ID!) {
+        exportProjectToEos(projectId: $projectId) {
+          projectId
+          projectName
+          asciiContent
+          filenameSuffix
+          warnings {
+            code
+            severity
+            message
+            context { key value }
+          }
+        }
+      }
+    `;
+
+    const data = await this.query(mutation, { projectId });
+    return data.exportProjectToEos;
+  }
+}
+
+export interface EosWarningContextEntry {
+  key: string;
+  value: string;
+}
+
+export interface EosWarning {
+  code: string;
+  severity: 'INFO' | 'WARN';
+  message: string;
+  context: EosWarningContextEntry[];
+}
+
+export interface EosImportResult {
+  projectId: string;
+  fixtureDefinitionsCount: number;
+  fixtureInstancesCount: number;
+  looksCount: number;
+  cueListsCount: number;
+  cuesCount: number;
+  groupsCount: number;
+  warnings: EosWarning[];
+  synthesizedDefinitionIds: string[];
+}
+
+export interface EosExportResult {
+  projectId: string;
+  projectName: string;
+  asciiContent: string;
+  filenameSuffix: string;
+  warnings: EosWarning[];
 }

--- a/src/tools/eos-tools.ts
+++ b/src/tools/eos-tools.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import {
+  LacyLightsGraphQLClient,
+  EosImportResult,
+  EosExportResult,
+} from '../services/graphql-client-simple';
+
+const ImportEosAsciiSchema = z.object({
+  asciiContent: z.string().describe('Full text content of the ETC Eos ASCII (.asc) showfile'),
+  newProjectName: z.string().optional().describe('Optional explicit project name. If omitted, uses the showfile $$Title or originalFileName'),
+  targetProjectId: z.string().optional().describe('Optional existing project ID to import into. Mutually exclusive with newProjectName'),
+});
+
+const ExportEosAsciiSchema = z.object({
+  projectId: z.string().describe('Project ID to export to ETC Eos ASCII'),
+});
+
+export class EosTools {
+  constructor(private graphqlClient: LacyLightsGraphQLClient) {}
+
+  async importEosAscii(args: z.infer<typeof ImportEosAsciiSchema>): Promise<EosImportResult> {
+    const parsed = ImportEosAsciiSchema.parse(args);
+
+    if (parsed.newProjectName && parsed.targetProjectId) {
+      throw new Error('Provide either newProjectName or targetProjectId, not both');
+    }
+
+    const options =
+      parsed.newProjectName || parsed.targetProjectId
+        ? {
+            newProjectName: parsed.newProjectName,
+            targetProjectId: parsed.targetProjectId,
+          }
+        : undefined;
+
+    return this.graphqlClient.importEosAscii(parsed.asciiContent, options);
+  }
+
+  async exportEosAscii(args: z.infer<typeof ExportEosAsciiSchema>): Promise<EosExportResult> {
+    const parsed = ExportEosAsciiSchema.parse(args);
+    return this.graphqlClient.exportEosAscii(parsed.projectId);
+  }
+}

--- a/src/tools/eos-tools.ts
+++ b/src/tools/eos-tools.ts
@@ -7,7 +7,7 @@ import {
 
 const ImportEosAsciiSchema = z.object({
   asciiContent: z.string().describe('Full text content of the ETC Eos ASCII (.asc) showfile'),
-  newProjectName: z.string().optional().describe('Optional explicit project name. If omitted, uses the showfile $$Title or originalFileName'),
+  newProjectName: z.string().optional().describe('Optional explicit project name. If omitted, uses the showfile $$Title or a backend default'),
   targetProjectId: z.string().optional().describe('Optional existing project ID to import into. Mutually exclusive with newProjectName'),
 });
 

--- a/tests/tools/eos-tools.test.ts
+++ b/tests/tools/eos-tools.test.ts
@@ -1,0 +1,136 @@
+import { EosTools } from '../../src/tools/eos-tools';
+import { LacyLightsGraphQLClient } from '../../src/services/graphql-client-simple';
+
+jest.mock('../../src/services/graphql-client-simple');
+const MockGraphQLClient = LacyLightsGraphQLClient as jest.MockedClass<typeof LacyLightsGraphQLClient>;
+
+describe('EosTools', () => {
+  let eosTools: EosTools;
+  let mockGraphQLClient: jest.Mocked<LacyLightsGraphQLClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGraphQLClient = {
+      importEosAscii: jest.fn(),
+      exportEosAscii: jest.fn(),
+    } as any;
+
+    MockGraphQLClient.mockImplementation(() => mockGraphQLClient);
+    eosTools = new EosTools(mockGraphQLClient);
+  });
+
+  describe('importEosAscii', () => {
+    it('forwards content and returns import result with warnings', async () => {
+      mockGraphQLClient.importEosAscii.mockResolvedValue({
+        projectId: 'p1',
+        fixtureDefinitionsCount: 2,
+        fixtureInstancesCount: 5,
+        looksCount: 3,
+        cueListsCount: 1,
+        cuesCount: 3,
+        groupsCount: 0,
+        warnings: [
+          { code: 'EFFECT_SKIPPED', severity: 'INFO', message: 'eff', context: [] },
+        ],
+        synthesizedDefinitionIds: [],
+      });
+
+      const result = await eosTools.importEosAscii({
+        asciiContent: 'Ident 3:0\n',
+      });
+
+      expect(mockGraphQLClient.importEosAscii).toHaveBeenCalledWith('Ident 3:0\n', undefined);
+      expect(result.fixtureInstancesCount).toBe(5);
+      expect(result.warnings[0].code).toBe('EFFECT_SKIPPED');
+    });
+
+    it('passes newProjectName through options', async () => {
+      mockGraphQLClient.importEosAscii.mockResolvedValue({
+        projectId: 'p2',
+        fixtureDefinitionsCount: 0,
+        fixtureInstancesCount: 0,
+        looksCount: 0,
+        cueListsCount: 0,
+        cuesCount: 0,
+        groupsCount: 0,
+        warnings: [],
+        synthesizedDefinitionIds: [],
+      });
+
+      await eosTools.importEosAscii({
+        asciiContent: 'X',
+        newProjectName: 'My Show',
+      });
+
+      expect(mockGraphQLClient.importEosAscii).toHaveBeenCalledWith('X', {
+        newProjectName: 'My Show',
+        targetProjectId: undefined,
+      });
+    });
+
+    it('passes targetProjectId through options', async () => {
+      mockGraphQLClient.importEosAscii.mockResolvedValue({
+        projectId: 'p3',
+        fixtureDefinitionsCount: 0,
+        fixtureInstancesCount: 0,
+        looksCount: 0,
+        cueListsCount: 0,
+        cuesCount: 0,
+        groupsCount: 0,
+        warnings: [],
+        synthesizedDefinitionIds: [],
+      });
+
+      await eosTools.importEosAscii({
+        asciiContent: 'X',
+        targetProjectId: 'p3',
+      });
+
+      expect(mockGraphQLClient.importEosAscii).toHaveBeenCalledWith('X', {
+        newProjectName: undefined,
+        targetProjectId: 'p3',
+      });
+    });
+
+    it('rejects when both newProjectName and targetProjectId are set', async () => {
+      await expect(
+        eosTools.importEosAscii({
+          asciiContent: 'X',
+          newProjectName: 'A',
+          targetProjectId: 'p1',
+        }),
+      ).rejects.toThrow(/either newProjectName or targetProjectId/);
+
+      expect(mockGraphQLClient.importEosAscii).not.toHaveBeenCalled();
+    });
+
+    it('throws when asciiContent is missing', async () => {
+      await expect(eosTools.importEosAscii({} as any)).rejects.toThrow();
+      expect(mockGraphQLClient.importEosAscii).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exportEosAscii', () => {
+    it('forwards projectId and returns export result', async () => {
+      mockGraphQLClient.exportEosAscii.mockResolvedValue({
+        projectId: 'p1',
+        projectName: 'Show',
+        asciiContent: 'Ident 3:0\n...\n',
+        filenameSuffix: '.asc',
+        warnings: [],
+      });
+
+      const result = await eosTools.exportEosAscii({ projectId: 'p1' });
+
+      expect(mockGraphQLClient.exportEosAscii).toHaveBeenCalledWith('p1');
+      expect(result.asciiContent).toContain('Ident');
+      expect(result.filenameSuffix).toBe('.asc');
+    });
+
+    it('throws when projectId is missing', async () => {
+      await expect(eosTools.exportEosAscii({} as any)).rejects.toThrow();
+      expect(mockGraphQLClient.exportEosAscii).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the Eos ASCII importer/exporter feature (plan: `lacylights/docs/plans/2026-04-28-eos-ascii-importer-exporter-implementation.md`, Tasks 29-31).

Adds two new MCP tools that wrap the backend's \`importProjectFromEos\` / \`exportProjectToEos\` GraphQL mutations:

- **\`import_eos_ascii(asciiContent, newProjectName?, targetProjectId?)\`** — imports an ETC Eos ASCII (\`.asc\`) showfile into a new or existing LacyLights project. Returns counts of fixtures/looks/cues/groups created plus structured warnings (e.g. \`EFFECT_SKIPPED\`, \`UNPATCHED_CHANNEL\`).
- **\`export_eos_ascii(projectId)\`** — exports a LacyLights project as \`.asc\` text. LacyLights-only concepts (Look Boards, per-channel fade behaviors, synthesized definitions) ride along as \`\$\$ LACYLIGHTS:\` sidecar comments so re-import preserves them.

### Backend schema vs plan

The plan template assumed an \`originalFileName\` arg and a nested \`project { id name }\` result, but the actual backend schema (lacylights-go \`schema.graphql\`) uses:

- \`importProjectFromEos(asciiContent: String!, options: EosImportOptionsInput)\` returning \`projectId: ID!\`
- \`EosImportOptionsInput { newProjectName, targetProjectId }\` (no \`groupId\`)
- \`EosExportResult { projectId, projectName, asciiContent, filenameSuffix, warnings }\`

Implementation matches the real schema. The mutually-exclusive \`newProjectName\` vs \`targetProjectId\` constraint is enforced at the tool layer so callers get a clear error before the backend rejects.

## Implementation

- \`src/services/graphql-client-simple.ts\` — \`importEosAscii\` / \`exportEosAscii\` methods plus \`EosImportResult\` / \`EosExportResult\` / \`EosWarning\` interfaces.
- \`src/tools/eos-tools.ts\` — \`EosTools\` class with Zod-validated args.
- \`src/index.ts\` — instantiation + \`ListTools\` definitions + \`CallTool\` handlers.
- \`tests/tools/eos-tools.test.ts\` — 7 unit tests covering happy paths, options forwarding, mutual-exclusion guard, and missing-arg validation.

## Test plan

- [x] \`npm test\` — 653 tests pass (19 suites)
- [x] \`npm run build\` — clean
- [x] \`npm run lint\` — clean
- [ ] Manual smoke test against running backend (requires lacylights-go on \`:4000\` with the Eos mutations from PR #76 / #77 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)